### PR TITLE
Add support for python 3

### DIFF
--- a/python/aggregate_time_series_data.py
+++ b/python/aggregate_time_series_data.py
@@ -15,7 +15,7 @@ import numpy
 def aggregate_time_series_data(data, aggregate_size, wgts, debug = False):
     nt = data.shape[0]
 
-    n_aggregates = int(nt/aggregate_size)
+    n_aggregates = int(nt // aggregate_size)
 
     # concatenating tuples to create shape for aggregate_data
     agg_shape = (n_aggregates,) + data.shape[1:]

--- a/python/aggregate_time_series_data.py
+++ b/python/aggregate_time_series_data.py
@@ -20,10 +20,10 @@ def aggregate_time_series_data(data, aggregate_size, wgts, debug = False):
     # concatenating tuples to create shape for aggregate_data
     agg_shape = (n_aggregates,) + data.shape[1:]
 
-    print __name__, 'agg_shape: ', agg_shape
+    print(__name__, 'agg_shape: ', agg_shape)
 
     aggregate_data = numpy.ma.zeros((agg_shape))
-    print "aggregate_data.shape: ", aggregate_data.shape
+    print("aggregate_data.shape: ", aggregate_data.shape)
 
     if data.ndim == 1:
         for i in range(0, n_aggregates):
@@ -33,6 +33,6 @@ def aggregate_time_series_data(data, aggregate_size, wgts, debug = False):
         for i in range(0, n_aggregates):
             aggregate_data[i, ::] = numpy.ma.average(data[i*aggregate_size:(i+1) * aggregate_size, ::], axis = 0, weights = wgts)
 
-    print "aggregate_data.shape: ", aggregate_data.shape
+    print("aggregate_data.shape: ", aggregate_data.shape)
 
     return aggregate_data

--- a/python/aggregate_time_series_data.py
+++ b/python/aggregate_time_series_data.py
@@ -8,6 +8,8 @@
 # to compute mean (aggregates) of time series data at different intervals,
 # for e.g. to compute annual mean from daily timeseries data.
 
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import numpy
 
 def aggregate_time_series_data(data, aggregate_size, wgts, debug = False):

--- a/python/aggregate_ts_weighted.py
+++ b/python/aggregate_ts_weighted.py
@@ -1,14 +1,16 @@
 #
 # Copyright (c) 2017, UT-BATTELLE, LLC
 # All rights reserved.
-# 
+#
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import numpy
 
 def aggregate_ts_weighted(ts, bw, wgts = 1, debug = False):
- 
+
     nt = ts.shape[0]
     n_agg_ts = nt/bw
 

--- a/python/aggregate_ts_weighted.py
+++ b/python/aggregate_ts_weighted.py
@@ -14,18 +14,22 @@ def aggregate_ts_weighted(ts, bw, wgts = 1, debug = False):
     nt = ts.shape[0]
     n_agg_ts = nt/bw
 
-    if debug: print __name__, 'nyrs_ts: ', n_agg_ts
+    if debug:
+        print(__name__, 'nyrs_ts: ', n_agg_ts)
 
     ts_reshape = numpy.reshape(ts, (n_agg_ts, bw))
 
-    if debug: print __name__, 'ts_reshape: ', ts_reshape
+    if debug:
+        print(__name__, 'ts_reshape: ', ts_reshape)
 
     ts_reshape_wgted = wgts * ts_reshape
 
-    if debug: print __name__, 'ts_reshape_wgted: ', ts_reshape_wgted
+    if debug:
+        print(__name__, 'ts_reshape_wgted: ', ts_reshape_wgted)
 
     agg_ts = numpy.sum(ts_reshape_wgted, axis = 1)/numpy.sum(wgts)
 
-    if debug: print __name__, 'area_seasonal_avg: ', agg_ts
+    if debug:
+        print(__name__, 'area_seasonal_avg: ', agg_ts)
 
     return agg_ts

--- a/python/aggregate_ts_weighted.py
+++ b/python/aggregate_ts_weighted.py
@@ -12,7 +12,7 @@ import numpy
 def aggregate_ts_weighted(ts, bw, wgts = 1, debug = False):
 
     nt = ts.shape[0]
-    n_agg_ts = nt/bw
+    n_agg_ts = nt // bw
 
     if debug:
         print(__name__, 'nyrs_ts: ', n_agg_ts)

--- a/python/compute_contour_levels.py
+++ b/python/compute_contour_levels.py
@@ -18,8 +18,8 @@ def compute_contour_levels(field, n_stddev, num_levels):
         range_plot = 2 * max_plot_temp
         max_plot    = round_to_first_given_range(x = max_plot_temp, range_x = range_plot)
 
-        print __name__, 'max_plot_temp: ', max_plot_temp
-        print __name__, 'max_plot: ', max_plot
+        print(__name__, 'max_plot_temp: ', max_plot_temp)
+        print(__name__, 'max_plot: ', max_plot)
 
         levels = numpy.linspace(-max_plot, max_plot, num = num_levels)
 
@@ -41,11 +41,12 @@ def compute_contour_levels(field, n_stddev, num_levels):
         max_plot = round_to_first_given_range(max_plot_temp, range_x = range_plot)
         min_plot = round_to_first_given_range(min_plot_temp, range_x = range_plot)
 
-        print __name__, 'min_plot_temp, max_plot_temp: ', min_plot_temp, max_plot_temp
-        print __name__, 'min_plot, max_plot: ', min_plot, max_plot
+        print(__name__, 'min_plot_temp, max_plot_temp: ', min_plot_temp,
+              max_plot_temp)
+        print(__name__, 'min_plot, max_plot: ', min_plot, max_plot)
 
         levels = numpy.linspace(min_plot, max_plot, num = num_levels)
 
-    print 'contour levels: ', levels
+    print('contour levels: ', levels)
 
     return levels

--- a/python/compute_contour_levels.py
+++ b/python/compute_contour_levels.py
@@ -1,10 +1,12 @@
 #
 # Copyright (c) 2017, UT-BATTELLE, LLC
 # All rights reserved.
-# 
+#
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import numpy
 from round_to_first import round_to_first
 from round_to_first_given_range import round_to_first_given_range
@@ -13,13 +15,13 @@ def compute_contour_levels(field, n_stddev, num_levels):
 
     if numpy.ma.min(field[:]) < 0 and numpy.ma.max(field[:]) > 0:
         max_plot_temp = numpy.ma.mean(field) + n_stddev * numpy.ma.std(field)
-        range_plot = 2 * max_plot_temp 
+        range_plot = 2 * max_plot_temp
         max_plot    = round_to_first_given_range(x = max_plot_temp, range_x = range_plot)
 
         print __name__, 'max_plot_temp: ', max_plot_temp
         print __name__, 'max_plot: ', max_plot
 
-        levels = numpy.linspace(-max_plot, max_plot, num = num_levels)    
+        levels = numpy.linspace(-max_plot, max_plot, num = num_levels)
 
     else:
         max_plot_temp = numpy.ma.mean(field[:]) + \
@@ -38,12 +40,12 @@ def compute_contour_levels(field, n_stddev, num_levels):
 
         max_plot = round_to_first_given_range(max_plot_temp, range_x = range_plot)
         min_plot = round_to_first_given_range(min_plot_temp, range_x = range_plot)
-        
+
         print __name__, 'min_plot_temp, max_plot_temp: ', min_plot_temp, max_plot_temp
         print __name__, 'min_plot, max_plot: ', min_plot, max_plot
 
         levels = numpy.linspace(min_plot, max_plot, num = num_levels)
 
     print 'contour levels: ', levels
-    
+
     return levels

--- a/python/compute_diff_index.py
+++ b/python/compute_diff_index.py
@@ -6,6 +6,9 @@
 # in the LICENSE file in the top level a-prime directory
 #
 
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
 import matplotlib as mpl
 #changing the default backend to agg to resolve contouring issue on rhea
 mpl.use('Agg')

--- a/python/compute_diff_index.py
+++ b/python/compute_diff_index.py
@@ -57,7 +57,7 @@ def compute_diff_index   (archive_dir,
     n_reg = len(regs)
 
     for i,reg in enumerate(regs):
-        print __name__, 'casename: ', casename
+        print(__name__, 'casename: ', casename)
         area_seasonal_avg, n_months_season, units = get_reg_seasonal_avg (
                                   indir     = archive_dir,
                                   casename     = casename,
@@ -86,7 +86,8 @@ def compute_diff_index   (archive_dir,
             units = 'unitless'
 
 
-        if debug: print __name__, 'test_ts: ', test_ts
+        if debug:
+            print(__name__, 'test_ts: ', test_ts)
 
 
     index = test_ts[0, :] - test_ts[-1, :]
@@ -117,8 +118,8 @@ def compute_diff_index   (archive_dir,
                       debug         = debug)
 
 
-    print "Writing ", outfile
-    print ""
+    print("Writing ", outfile)
+    print("")
 
     f_write = Dataset(outfile, 'w', format = 'NETCDF4')
 
@@ -218,7 +219,7 @@ if __name__ == "__main__":
     colors = ['b', 'g', 'r', 'c', 'm', 'y']
 
     x = mpl.get_backend()
-    print 'backend: ', x
+    print('backend: ', x)
 
     compute_diff_index(archive_dir = archive_dir,
                        indir = indir,

--- a/python/compute_index.py
+++ b/python/compute_index.py
@@ -6,6 +6,9 @@
 # in the LICENSE file in the top level a-prime directory
 #
 
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
 import matplotlib as mpl
 #changing the default backend to agg to resolve contouring issue on rhea
 mpl.use('Agg')

--- a/python/compute_index.py
+++ b/python/compute_index.py
@@ -52,8 +52,8 @@ def compute_index   (archive_dir,
                write_netcdf,
                debug = False):
 
-    print __name__, 'casename: ', casename
-    print __name__, 'reg: ', reg
+    print(__name__, 'casename: ', casename)
+    print(__name__, 'reg: ', reg)
     area_seasonal_avg, n_months_season, units = get_reg_seasonal_avg (
                               indir     = archive_dir,
                               casename     = casename,
@@ -107,8 +107,8 @@ def compute_index   (archive_dir,
                           debug         = debug)
 
 
-        print "Writing ", outfile
-        print ""
+        print("Writing ", outfile)
+        print("")
 
         f_write = Dataset(outfile, 'w', format = 'NETCDF4')
 
@@ -205,7 +205,7 @@ if __name__ == "__main__":
     colors = ['b', 'g', 'r', 'c', 'm', 'y']
 
     x = mpl.get_backend()
-    print 'backend: ', x
+    print('backend: ', x)
 
     compute_index(archive_dir = archive_dir,
                   indir = indir,

--- a/python/compute_reg_seasonal_climo_and_stddev.py
+++ b/python/compute_reg_seasonal_climo_and_stddev.py
@@ -46,7 +46,8 @@ def compute_reg_seasonal_climo_and_stddev(indir,
     a, n_months_season = get_season_months_index(begin_month, end_month)
 
     day_wgts = get_days_in_season_months(begin_month, end_month)
-    if debug: print __name__, 'day_wgts: ', day_wgts
+    if debug:
+        print(__name__, 'day_wgts: ', day_wgts)
 
     seasonal_avg_ts = aggregate_time_series_data(    data = field,
                               aggregate_size = n_months_season,

--- a/python/compute_reg_seasonal_climo_and_stddev.py
+++ b/python/compute_reg_seasonal_climo_and_stddev.py
@@ -1,10 +1,14 @@
 #
 # Copyright (c) 2017, UT-BATTELLE, LLC
 # All rights reserved.
-# 
+#
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
 import numpy
 from netCDF4 import Dataset
 
@@ -14,7 +18,7 @@ from get_days_in_season_months import get_days_in_season_months
 from aggregate_time_series_data import aggregate_time_series_data
 
 def compute_reg_seasonal_climo_and_stddev(indir,
-              casename, 
+              casename,
               field_name,
                   interp_grid,
               interp_method,

--- a/python/create_climatology.py
+++ b/python/create_climatology.py
@@ -60,7 +60,7 @@ end_month   = options.end_month
 file_name = indir + '/' + casename + '.cam.h0.' + field_name + \
         '.' + str(begin_yr) + '-' + str(end_yr) + '.nc'
 
-print "file_name: ", file_name
+print("file_name: ", file_name)
 
 f = Dataset(file_name, 'r')
 
@@ -71,8 +71,8 @@ lon = f.variables['lon']
 ntime = field.shape[0]
 ncol  = field.shape[1]
 
-print "field.shape: ", field.shape
-print "field.units: ", field.units
+print("field.shape: ", field.shape)
+print("field.units: ", field.units)
 
 t0 = time.clock()
 
@@ -81,7 +81,7 @@ end_index = ncol
 
 local_field = field[:,begin_index:end_index]
 
-print "file read!, time taken: ", str(time.clock()-t0)
+print("file read!, time taken: ", str(time.clock()-t0))
 
 nyrs = ntime/12
 clim_field = numpy.zeros((12, ncol))
@@ -90,20 +90,20 @@ clim_field = numpy.zeros((12, ncol))
 #Computing the climatology of each month
 for month in range(0, 12):
     i = numpy.arange(0,nyrs) * 12 + month
-    # print i
+    # print(i
     clim_field[month, :] = numpy.mean(field[i, :], axis = 0)
 
 units_out = field.units
 
 if field_name[0:4] == 'PREC':
-    print 'A precipitation field! Changing units to mm/day!...'
+    print('A precipitation field! Changing units to mm/day!...')
     clim_field = clim_field * 86400.0 * 1000.0
     units_out = 'mm/day'
 
 seasonal_clim = numpy.zeros((ncol))
 days_in_month = numpy.array([31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31])
 
-print 'begin_month, end_month:', begin_month, end_month
+print('begin_month, end_month:', begin_month, end_month)
 
 #Setting up months in the prescribed season
 if (begin_month <= end_month):
@@ -117,13 +117,13 @@ else:
     seasonal_index[0:11-begin_month+1]       = numpy.arange(begin_month, 12)
     seasonal_index[11-begin_month+1:n_months]  = numpy.arange(0, end_month+1)
 
-print "seasonal_index: ", seasonal_index
-print "seasonal_index.shape: ", seasonal_index.shape
-print "clim_field.shape: ", clim_field.shape
+print("seasonal_index: ", seasonal_index)
+print("seasonal_index.shape: ", seasonal_index.shape)
+print("clim_field.shape: ", clim_field.shape)
 
 weights = numpy.zeros((n_months))
 weights[:] = days_in_month[seasonal_index]
-print "weights: ", weights
+print("weights: ", weights)
 
 #Computing seasonal mean
 seasonal_clim[:] = numpy.average(clim_field[seasonal_index, :], axis = 0, weights = weights)
@@ -135,8 +135,8 @@ outfile = indir + '/'+ casename + '_' + season \
             + '_climo.' + field_name + \
         '.' + str(begin_yr) + '-' + str(end_yr) + '.nc'
 
-print "Writing ", outfile
-print ""
+print("Writing ", outfile)
+print("")
 
 f_write = Dataset(outfile, 'w', format = 'NETCDF3_64BIT')
 

--- a/python/create_climatology.py
+++ b/python/create_climatology.py
@@ -8,6 +8,8 @@
 # Compute the climatology for a case
 # Uses MPI
 
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import numpy
 from   scipy.io import netcdf
 from   netCDF4  import Dataset

--- a/python/create_climatology.py
+++ b/python/create_climatology.py
@@ -83,7 +83,7 @@ local_field = field[:,begin_index:end_index]
 
 print("file read!, time taken: ", str(time.clock()-t0))
 
-nyrs = ntime/12
+nyrs = ntime // 12
 clim_field = numpy.zeros((12, ncol))
 
 

--- a/python/get_climo_filename.py
+++ b/python/get_climo_filename.py
@@ -28,15 +28,15 @@ def get_climo_filename(    indir,
                 '.' + field_name + '.' + str(begin_yr) + '-' + str(end_yr) + '.nc'
 
 
-    print "file_name: ", file_name
+    print("file_name: ", file_name)
 
 
     try:
         f     = Dataset(file_name, "r")
 
     except (RuntimeError,IOError):
-        print
-        print file_name, " not found!"
+        print()
+        print(file_name, " not found!")
 
         if interp_grid == '0':
             file_name = indir + '/' + casename + '_' + season + '_' +\
@@ -46,8 +46,8 @@ def get_climo_filename(    indir,
                 'climo.' + interp_grid + '_' + interp_method + \
                 '.nc'
 
-        print
-        print "Using file: ", file_name
-        print
+        print()
+        print("Using file: ", file_name)
+        print()
 
     return file_name

--- a/python/get_climo_filename.py
+++ b/python/get_climo_filename.py
@@ -1,10 +1,12 @@
 #
 # Copyright (c) 2017, UT-BATTELLE, LLC
 # All rights reserved.
-# 
+#
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 from netCDF4 import Dataset
 
 
@@ -12,7 +14,7 @@ def get_climo_filename(    indir,
             casename,
             field_name,
             season,
-            begin_yr, 
+            begin_yr,
             end_yr,
             interp_grid,
             interp_method):

--- a/python/get_days_in_season_months.py
+++ b/python/get_days_in_season_months.py
@@ -1,10 +1,12 @@
 #
 # Copyright (c) 2017, UT-BATTELLE, LLC
 # All rights reserved.
-# 
+#
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import numpy
 from get_season_months_index import get_season_months_index
 

--- a/python/get_derived_var_expr.py
+++ b/python/get_derived_var_expr.py
@@ -32,7 +32,7 @@ def get_derived_var_expr (field_name):
     print
     print(field_name, 'derived from: ', var_expr.atoms(Symbol))
 
-    var_expr_numpy = lambdify(var_expr.atoms(Symbol), var_expr, "numpy")
+    var_expr_numpy = lambdify(var_expr.atoms(Symbol), var_expr, str("numpy"))
 
     return var_expr, var_expr_numpy
 

--- a/python/get_derived_var_expr.py
+++ b/python/get_derived_var_expr.py
@@ -26,11 +26,11 @@ def get_derived_var_expr (field_name):
         FLNS, FSNS, LHFLX, SHFLX = symbols('FLNS, FSNS, LHFLX, SHFLX')
         var_expr = FLNS - FSNS + LHFLX + SHFLX
     else:
-        print
-        print 'No derived variable list found for ', field_name
+        print()
+        print('No derived variable list found for ', field_name)
 
     print
-    print field_name, 'derived from: ', var_expr.atoms(Symbol)
+    print(field_name, 'derived from: ', var_expr.atoms(Symbol))
 
     var_expr_numpy = lambdify(var_expr.atoms(Symbol), var_expr, "numpy")
 

--- a/python/get_derived_var_expr.py
+++ b/python/get_derived_var_expr.py
@@ -1,10 +1,12 @@
 #
 # Copyright (c) 2017, UT-BATTELLE, LLC
 # All rights reserved.
-# 
+#
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import numpy
 from sympy import *
 

--- a/python/get_index_filename.py
+++ b/python/get_index_filename.py
@@ -1,27 +1,29 @@
 #
 # Copyright (c) 2017, UT-BATTELLE, LLC
 # All rights reserved.
-# 
+#
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 from get_season_name import get_season_name
 
 
 def get_index_filename (indir,
-              casename,      
-              index_name,    
-              field_name,    
-              interp_grid,   
-              interp_method, 
-              begin_yr,      
-              end_yr,        
-              begin_month,   
-              end_month,     
-              aggregate,     
-              no_ann,    
-              stdize,    
-              debug):         
+              casename,
+              index_name,
+              field_name,
+              interp_grid,
+              interp_method,
+              begin_yr,
+              end_yr,
+              begin_month,
+              end_month,
+              aggregate,
+              no_ann,
+              stdize,
+              debug):
 
     season = get_season_name(begin_month, end_month)
 
@@ -33,11 +35,11 @@ def get_index_filename (indir,
 
     if no_ann == 1:
         season_text = season + '_no_anncyc'
-    
+
     if stdize == 1:
         season_text = season + '_stdized'
 
-    if interp_grid == '0':    
+    if interp_grid == '0':
         outfile = indir + '/'+ casename + '_' + season_text + '.' + \
                     index_name + '_' + field_name + '.' + str(begin_yr) + '-' + str(end_yr) + '.nc'
     else:

--- a/python/get_reg_area_avg.py
+++ b/python/get_reg_area_avg.py
@@ -5,6 +5,8 @@
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import numpy
 
 def get_reg_area_avg(field, lat, lon, area_wgts, debug = False):

--- a/python/get_reg_area_avg.py
+++ b/python/get_reg_area_avg.py
@@ -17,7 +17,8 @@ def get_reg_area_avg(field, lat, lon, area_wgts, debug = False):
     else:
         nt   = field.shape[0]
 
-    if debug: print __name__, 'nlon, nlat: ', nlon, nlat
+    if debug:
+        print(__name__, 'nlon, nlat: ', nlon, nlat)
 
 
     area_average = numpy.zeros(nt)
@@ -28,9 +29,11 @@ def get_reg_area_avg(field, lat, lon, area_wgts, debug = False):
         for i in range(0,nt):
             area_average[i] = numpy.sum(field[i, :, :] * area_wgts[:, :])/numpy.sum(area_wgts)
 
-    print __name__, 'area_average.shape: ', area_average.shape
-    if debug: print __name__, 'area weights: ', area_wgts
-    if debug: print __name__, 'area weighted total_field: ', area_average
+    print(__name__, 'area_average.shape: ', area_average.shape)
+    if debug:
+        print(__name__, 'area weights: ', area_wgts)
+    if debug:
+        print(__name__, 'area weighted total_field: ', area_average)
 
 
 

--- a/python/get_reg_area_avg_rmse.py
+++ b/python/get_reg_area_avg_rmse.py
@@ -17,7 +17,8 @@ def get_reg_area_avg_rmse(field, lat, lon, area_wgts, debug = False):
     else:
         nt   = field.shape[0]
 
-    if debug: print __name__, 'nlon, nlat: ', nlon, nlat
+    if debug:
+        print(__name__, 'nlon, nlat: ', nlon, nlat)
 
     area_average_rmse = numpy.zeros(nt)
 
@@ -27,8 +28,9 @@ def get_reg_area_avg_rmse(field, lat, lon, area_wgts, debug = False):
         for i in range(0,nt):
             area_average_rmse[i] = numpy.sqrt(numpy.sum(numpy.power(field[i, :, :], 2.0) * area_wgts[:, :])/numpy.sum(area_wgts))
 
-    print __name__, 'area_average_rmse.shape: ', area_average_rmse.shape
-    if debug: print __name__, 'area weighted total_field: ', area_average_rmse
+    print(__name__, 'area_average_rmse.shape: ', area_average_rmse.shape)
+    if debug:
+        print(__name__, 'area weighted total_field: ', area_average_rmse)
 
 
 

--- a/python/get_reg_area_avg_rmse.py
+++ b/python/get_reg_area_avg_rmse.py
@@ -5,6 +5,8 @@
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import numpy
 
 def get_reg_area_avg_rmse(field, lat, lon, area_wgts, debug = False):

--- a/python/get_reg_avg_climo.py
+++ b/python/get_reg_avg_climo.py
@@ -1,10 +1,12 @@
 #
 # Copyright (c) 2017, UT-BATTELLE, LLC
 # All rights reserved.
-# 
+#
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import numpy
 from netCDF4             import Dataset
 
@@ -17,7 +19,7 @@ from aggregate_ts_weighted     import aggregate_ts_weighted
 from read_climo_file        import read_climo_file
 
 def get_reg_avg_climo (      indir,
-              casename, 
+              casename,
               field_name,
                   interp_grid,
               interp_method,

--- a/python/get_reg_box.py
+++ b/python/get_reg_box.py
@@ -1,10 +1,13 @@
 #
 # Copyright (c) 2017, UT-BATTELLE, LLC
 # All rights reserved.
-# 
+#
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
 def get_reg_box(reg):
 
     if reg == "global":
@@ -12,7 +15,7 @@ def get_reg_box(reg):
 
     if reg == "NH":
         lat_ll, lat_ul, lon_ll, lon_ul = 0, 90, 0, 360
-        
+
     if reg == "SH":
         lat_ll, lat_ul, lon_ll, lon_ul = -90, 0, 0, 360
 
@@ -42,7 +45,7 @@ def get_reg_box(reg):
 
     if reg == "Tropical_Pacific":
         lat_ll, lat_ul, lon_ll, lon_ul = -5, 5, 160, 270
-        
+
     if reg == "Greater_Tropical_Pacific":
         lat_ll, lat_ul, lon_ll, lon_ul = -30, 30, 120, 290
 

--- a/python/get_reg_meridional_avg.py
+++ b/python/get_reg_meridional_avg.py
@@ -17,7 +17,8 @@ def get_reg_meridional_avg(field, area_wgts, debug = False):
 
     meridional_avg = numpy.sum(field * area_wgts, axis = -2)/numpy.sum(area_wgts, axis = -2)
 
-    print __name__, 'meridional_avg.shape: ', meridional_avg.shape
-    if debug: print __name__, 'area weighted meridional avg.: ', meridional_avg
+    print(__name__, 'meridional_avg.shape: ', meridional_avg.shape)
+    if debug:
+        print(__name__, 'area weighted meridional avg.: ', meridional_avg)
 
     return meridional_avg

--- a/python/get_reg_meridional_avg.py
+++ b/python/get_reg_meridional_avg.py
@@ -5,6 +5,8 @@
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import numpy
 
 def get_reg_meridional_avg(field, area_wgts, debug = False):

--- a/python/get_reg_meridional_avg_climo.py
+++ b/python/get_reg_meridional_avg_climo.py
@@ -1,10 +1,13 @@
 #
 # Copyright (c) 2017, UT-BATTELLE, LLC
 # All rights reserved.
-# 
+#
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
 import numpy
 from netCDF4             import Dataset
 
@@ -18,7 +21,7 @@ from read_climo_file        import read_climo_file
 from get_reg_meridional_avg    import get_reg_meridional_avg
 
 def get_reg_meridional_avg_climo (      indir,
-              casename, 
+              casename,
               field_name,
                   interp_grid,
               interp_method,

--- a/python/get_reg_seasonal_avg.py
+++ b/python/get_reg_seasonal_avg.py
@@ -1,10 +1,12 @@
 #
 # Copyright (c) 2017, UT-BATTELLE, LLC
 # All rights reserved.
-# 
+#
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import numpy
 from netCDF4 import Dataset
 
@@ -15,7 +17,7 @@ from get_reg_area_avg import get_reg_area_avg
 from aggregate_ts_weighted import aggregate_ts_weighted
 
 def get_reg_seasonal_avg (indir,
-              casename, 
+              casename,
               field_name,
                   interp_grid,
               interp_method,

--- a/python/get_reg_seasonal_avg.py
+++ b/python/get_reg_seasonal_avg.py
@@ -52,7 +52,8 @@ def get_reg_seasonal_avg (indir,
     a, n_months_season = get_season_months_index(begin_month, end_month)
 
     day_wgts = get_days_in_season_months(begin_month, end_month)
-    if debug: print __name__, 'day_wgts: ', day_wgts
+    if debug:
+        print(__name__, 'day_wgts: ', day_wgts)
 
     if aggregate == 1:
         area_seasonal_avg = aggregate_ts_weighted(ts = area_average,

--- a/python/get_regress_index_field.py
+++ b/python/get_regress_index_field.py
@@ -42,7 +42,7 @@ def get_regress_index_field (indir,
                debug = False):
 
 
-    print __name__, 'casename: ', casename
+    print(__name__, 'casename: ', casename)
 
     index, n_months_season, units_index = get_reg_seasonal_avg (
                               indir         = indir[1],
@@ -89,7 +89,8 @@ def get_regress_index_field (indir,
     if aggregate == 1:
 
         day_wgts = get_days_in_season_months(begin_month[0], end_month[0])
-        if debug: print __name__, 'day_wgts: ', day_wgts
+        if debug:
+            print(__name__, 'day_wgts: ', day_wgts)
 
         field_seasonal_avg = aggregate_time_series_data(field, n_months_season, day_wgts)
 

--- a/python/get_regress_index_field.py
+++ b/python/get_regress_index_field.py
@@ -5,6 +5,8 @@
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import numpy
 from scipy import stats
 from netCDF4 import Dataset

--- a/python/get_regress_index_index.py
+++ b/python/get_regress_index_index.py
@@ -5,6 +5,8 @@
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import numpy
 from scipy import stats
 from netCDF4 import Dataset

--- a/python/get_regress_index_index.py
+++ b/python/get_regress_index_index.py
@@ -42,7 +42,7 @@ def get_regress_index_index (indir,
                debug = False):
 
 
-    print __name__, 'casename: ', casename
+    print(__name__, 'casename: ', casename)
 
     index, n_months_season, units_index = get_reg_seasonal_avg (
                               indir         = indir[1],
@@ -90,7 +90,8 @@ def get_regress_index_index (indir,
     if aggregate == 1:
 
         day_wgts = get_days_in_season_months(begin_month[0], end_month[0])
-        if debug: print __name__, 'day_wgts: ', day_wgts
+        if debug:
+            print(__name__, 'day_wgts: ', day_wgts)
 
         field_seasonal_avg = aggregate_time_series_data(field, n_months_season, day_wgts)
 

--- a/python/get_season_months_index.py
+++ b/python/get_season_months_index.py
@@ -1,10 +1,12 @@
 #
 # Copyright (c) 2017, UT-BATTELLE, LLC
 # All rights reserved.
-# 
+#
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import numpy
 
 def get_season_months_index(begin_month, end_month):
@@ -23,4 +25,4 @@ def get_season_months_index(begin_month, end_month):
             index_months = numpy.arange(begin_month, end_month+1)
 
 
-    return (index_months, n_months_season) 
+    return (index_months, n_months_season)

--- a/python/get_season_name.py
+++ b/python/get_season_name.py
@@ -1,31 +1,35 @@
 #
 # Copyright (c) 2017, UT-BATTELLE, LLC
 # All rights reserved.
-# 
+#
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
 from get_season_months_index import get_season_months_index
 
 def get_season_name(begin_month, end_month):
 
 
     initials = ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D']
-    month_no = ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12'] 
+    month_no = ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
 
     month_index, n_months = get_season_months_index(begin_month, end_month)
-    
+
 
     if n_months == 1:
         season_name = month_no[month_index]
-    
+
     else:
         season_name = ''
 
         for i in month_index:
             season_name = season_name + initials[i]
 
-        if begin_month == 0 and end_month == 11: 
+        if begin_month == 0 and end_month == 11:
             season_name = 'ANN'
 
     print 'season_name: ', season_name

--- a/python/get_season_name.py
+++ b/python/get_season_name.py
@@ -32,5 +32,5 @@ def get_season_name(begin_month, end_month):
         if begin_month == 0 and end_month == 11:
             season_name = 'ANN'
 
-    print 'season_name: ', season_name
+    print('season_name: ', season_name)
     return season_name

--- a/python/plot_climo.py
+++ b/python/plot_climo.py
@@ -99,9 +99,9 @@ plots_dir              = options.plots_dir
 #Get filename
 season = get_season_name(begin_month, end_month)
 
-print
-print 'Reading climo file for case: ', casename
-print
+print()
+print('Reading climo file for case: ', casename)
+print()
 
 field, lat, lon, area, units = read_climo_file(indir = indir, \
                      casename = casename, \
@@ -113,9 +113,9 @@ field, lat, lon, area, units = read_climo_file(indir = indir, \
                      interp_method = interp_method, \
                      reg = 'global')
 
-print
-print 'Reading climo file for case: ', ref_case
-print
+print()
+print('Reading climo file for case: ', ref_case)
+print()
 
 field_ref_case, lat, lon, area, units = read_climo_file(indir = ref_case_dir, \
                          casename = ref_case, \
@@ -158,13 +158,14 @@ min_plot      = round_to_first(min_plot_temp)
 
 levels = numpy.linspace(min_plot, max_plot, num = num)
 
-print
-print 'For climatology plots: '
-print 'mean, stddev, min_plot, max_plot ref_case: ', \
-        numpy.ma.mean(field_ref_case[:]), numpy.ma.std(field_ref_case[:]), min_plot, max_plot
-print 'min, max field: ', field_min, field_max
-print 'levels:', levels
-print
+print()
+print('For climatology plots: ')
+print('mean, stddev, min_plot, max_plot ref_case: ',
+      numpy.ma.mean(field_ref_case[:]), numpy.ma.std(field_ref_case[:]),
+      min_plot, max_plot)
+print('min, max field: ', field_min, field_max)
+print('levels:', levels)
+print()
 
 
 #Plot climotology
@@ -225,12 +226,12 @@ num         = 11
 max_plot    = round_to_first(4.0 * numpy.ma.std(field_diff))
 levels_diff = numpy.linspace(-max_plot, max_plot, num = num)
 
-print
-print 'For difference plot: '
-print 'mean, stddev, max_plot: ', \
-        numpy.ma.mean(field_diff), numpy.ma.std(field_diff), max_plot
-print 'min, max: ', numpy.ma.min(field_diff), numpy.ma.max(field_diff)
-print 'contour levels: ', levels_diff
+print()
+print('For difference plot: ')
+print('mean, stddev, max_plot: ', numpy.ma.mean(field_diff),
+      numpy.ma.std(field_diff), max_plot)
+print('min, max: ', numpy.ma.min(field_diff), numpy.ma.max(field_diff))
+print('contour levels: ', levels_diff)
 
 #Plot difference plot
 ax = f.add_subplot(3,1,3)

--- a/python/plot_climo.py
+++ b/python/plot_climo.py
@@ -6,6 +6,9 @@
 # in the LICENSE file in the top level a-prime directory
 #
 
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
 import matplotlib as mpl
 #changing the default backend to agg to resolve contouring issue on rhea
 mpl.use('Agg')

--- a/python/plot_climo_ne120_and_GPCP_test.py
+++ b/python/plot_climo_ne120_and_GPCP_test.py
@@ -70,7 +70,7 @@ if field_name == 'PRECT':
                 '.climo.' + str(begin_month) + '_' + str(end_month) + \
                 '.GPCP_conservative_mapping.' + 'PRECC.nc'
 
-    print "file_name: ", file_name_PRECC
+    print("file_name: ", file_name_PRECC)
 
 
     f_PRECC = Dataset(file_name_PRECC, "r")
@@ -85,7 +85,7 @@ if field_name == 'PRECT':
                 '.climo.' + str(begin_month) + '_' + str(end_month) + \
                 '.GPCP_conservative_mapping.' + 'PRECL.nc'
 
-    print "file_name: ", file_name_PRECL
+    print("file_name: ", file_name_PRECL)
 
 
     f_PRECL = Dataset(file_name_PRECL, "r")
@@ -100,7 +100,7 @@ else:
                 '.climo.' + str(begin_month) + '_' + str(end_month) + \
             '.GPCP_conservative_mapping.' + field_name + '.nc'
 
-    print "file_name: ", file_name
+    print("file_name: ", file_name)
 
 
     f = Dataset(file_name, "r")
@@ -111,14 +111,14 @@ else:
     lon = f.variables['lon']
     units = field.units
 
-print 'field.shape: ', field.shape
+print('field.shape: ', field.shape)
 
 
 season = get_season_name(begin_month, end_month)
 
 file_GPCP = GPCP_dir + '/' + 'GPCP_' + season + '_climo.nc'
 
-print "Using GPCP file: ", file_GPCP
+print("Using GPCP file: ", file_GPCP)
 
 f_GPCP = Dataset(file_GPCP, "r")
 

--- a/python/plot_climo_ne120_and_GPCP_test.py
+++ b/python/plot_climo_ne120_and_GPCP_test.py
@@ -6,6 +6,9 @@
 # in the LICENSE file in the top level a-prime directory
 #
 
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
 from mpl_toolkits.basemap import Basemap
 import matplotlib.pyplot as plt
 import matplotlib as mpl

--- a/python/plot_climo_vector.py
+++ b/python/plot_climo_vector.py
@@ -155,9 +155,9 @@ field_Y_plot.mask = numpy.where(field_mask[:,:] < 0.5, 1, 0)
 field_XY = numpy.ma.sqrt(numpy.ma.power(field_X_plot, 2.0) + numpy.ma.power(field_Y_plot, 2.0))
 
 
-print
-print 'Reading climo file for case: ', ref_case
-print
+print()
+print('Reading climo file for case: ', ref_case)
+print()
 
 field_ref_case_X, lat, lon, area, units = read_climo_file(indir = ref_case_dir, \
                      casename = ref_case, \
@@ -210,10 +210,10 @@ field_min_TAU       = numpy.ma.min(field_XY)
 field_max_ERS_TAU = numpy.ma.max(field_ref_case_XY)
 field_min_ERS_TAU = numpy.ma.min(field_ref_case_XY)
 
-print 'mean, stddev, min_plot, max_plot: ', \
-    numpy.ma.mean(field_XY), numpy.ma.std(field_XY), min_plot, max_plot
-print 'min, max: ', field_min_TAU, field_max_TAU
-print 'levels:', levels
+print('mean, stddev, min_plot, max_plot: ',
+      numpy.ma.mean(field_XY), numpy.ma.std(field_XY), min_plot, max_plot)
+print('min, max: ', field_min_TAU, field_max_TAU)
+print('levels:', levels)
 
 
 
@@ -297,11 +297,11 @@ num         = 11
 max_plot    = round_to_first(3.0 * numpy.ma.std(field_diff_XY))
 levels_diff = numpy.linspace(-max_plot, max_plot, num = num)
 
-print 'For difference plot: '
-print 'mean, stddev, max_plot: ', \
-    numpy.ma.mean(field_diff_XY), numpy.ma.std(field_diff_XY), max_plot
-print 'min, max: ', numpy.ma.min(field_diff_XY), numpy.ma.max(field_diff_XY)
-print 'contour levels: ', levels
+print('For difference plot: ')
+print('mean, stddev, max_plot: ', numpy.ma.mean(field_diff_XY),
+      numpy.ma.std(field_diff_XY), max_plot)
+print('min, max: ', numpy.ma.min(field_diff_XY), numpy.ma.max(field_diff_XY))
+print('contour levels: ', levels)
 
 #Computing difference vectors
 field_diff_X = field_X_plot - field_ref_case_X_plot

--- a/python/plot_climo_vector.py
+++ b/python/plot_climo_vector.py
@@ -8,6 +8,9 @@
 #python script to plot wind stress vectors and magnitude over the oceans using
 #CF variables TAUX and TAUY
 
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
 import matplotlib as mpl
 #changing the default backend to agg to resolve contouring issue on rhea
 mpl.use('Agg')

--- a/python/plot_diff_index.py
+++ b/python/plot_diff_index.py
@@ -6,6 +6,9 @@
 # in the LICENSE file in the top level a-prime directory
 #
 
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
 import matplotlib as mpl
 #changing the default backend to agg to resolve contouring issue on rhea
 mpl.use('Agg')

--- a/python/plot_diff_index.py
+++ b/python/plot_diff_index.py
@@ -183,13 +183,13 @@ def plot_diff_index   (indir,
 
         if begin_month == 0 and end_month == 11 and aggregate == 0:
             bw   = 13
-            wgts = numpy.ones(bw)/bw
-            nyrs = nt/n_months_season
+            wgts = numpy.ones(bw) // bw
+            nyrs = nt // n_months_season
 
 
             plot_ts_moving_avg = numpy.convolve(plot_ts, wgts, 'valid')
 
-            smooth_line, = ax[k].plot(plot_time[bw/2:-bw/2+1], plot_ts_moving_avg,
+            smooth_line, = ax[k].plot(plot_time[bw // 2:-bw // 2+1], plot_ts_moving_avg,
                             color = colors[i],
                             linewidth = 2.0,
                             label = 'Moving avg. (Bandwidth = ' + "%3d" % bw + ' months)')

--- a/python/plot_diff_index.py
+++ b/python/plot_diff_index.py
@@ -60,7 +60,7 @@ def plot_diff_index   (indir,
     n_reg = len(regs)
 
     for i,reg in enumerate(regs):
-        print __name__, 'casename: ', casename
+        print(__name__, 'casename: ', casename)
         area_seasonal_avg, n_months_season, units = get_reg_seasonal_avg (
                                   indir     = indir,
                                   casename     = casename,
@@ -88,14 +88,15 @@ def plot_diff_index   (indir,
             test_ts[i, :] = area_seasonal_avg_stddize
 
 
-        if debug: print __name__, 'test_ts: ', test_ts
+        if debug:
+            print(__name__, 'test_ts: ', test_ts)
 
 
     test_plot_ts = test_ts[0, :] - test_ts[-1, :]
 
 
     for i,reg in enumerate(regs):
-        print __name__, 'casename: ', casename
+        print(__name__, 'casename: ', casename)
         area_seasonal_avg, n_months_season, units = get_reg_seasonal_avg (
                                   indir     = ref_case_dir,
                                   casename     = ref_case,
@@ -123,7 +124,8 @@ def plot_diff_index   (indir,
             ref_ts[i, :] = area_seasonal_avg_stddize
 
 
-        if debug: print __name__, 'test_plot_ts: ', test_plot_ts
+        if debug:
+            print(__name__, 'test_plot_ts: ', test_plot_ts)
 
     ref_plot_ts = ref_ts[0, :] - ref_ts[-1, :]
 
@@ -157,8 +159,10 @@ def plot_diff_index   (indir,
         else:
             plot_time = numpy.arange(0,nt)
 
-        if debug: print __name__, 'plot_time: ', plot_time
-        if debug: print __name__, 'plot_begin_yr: ', plot_begin_yr
+        if debug:
+            print(__name__, 'plot_time: ', plot_time)
+        if debug:
+            print(__name__, 'plot_begin_yr: ', plot_begin_yr)
 
         plot_ts_mean   = numpy.mean(plot_ts)
         plot_ts_stddev = numpy.std(plot_ts)
@@ -171,8 +175,8 @@ def plot_diff_index   (indir,
 
         ax[k].axis([plot_time[0],plot_time[-1], y_axis_ll, y_axis_ul])
 
-        print 'plot_time[0],plot_time[-1], 1.1*min_plot, 1.1*max_plot: ', \
-            plot_time[0],plot_time[-1], 1.1*min_plot, 1.1*max_plot
+        print('plot_time[0],plot_time[-1], 1.1*min_plot, 1.1*max_plot: ',
+              plot_time[0],plot_time[-1], 1.1*min_plot, 1.1*max_plot)
 
         mean_line_plot = numpy.zeros(nt) + plot_ts_mean
         mean_line, = ax[k].plot(plot_time, mean_line_plot, color = 'black', linewidth = 1.0, label = 'Mean')
@@ -345,7 +349,7 @@ if __name__ == "__main__":
     colors = ['b', 'g', 'r', 'c', 'm', 'y']
 
     x = mpl.get_backend()
-    print 'backend: ', x
+    print('backend: ', x)
 
     plot_diff_index(indir = indir,
                     casename = casename,

--- a/python/plot_meridional_avg_climo.py
+++ b/python/plot_meridional_avg_climo.py
@@ -5,6 +5,8 @@
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import matplotlib as mpl
 #changing the default backend to agg to resolve contouring issue on rhea
 mpl.use('Agg')

--- a/python/plot_meridional_avg_climo.py
+++ b/python/plot_meridional_avg_climo.py
@@ -51,7 +51,7 @@ def plot_meridional_avg_climo (indir,
                debug = False):
 
 
-    print __name__, 'casename: ', casename
+    print(__name__, 'casename: ', casename)
     meridional_avg, lon_reg, units = get_reg_meridional_avg_climo (
                               indir     = indir,
                               casename     = casename,
@@ -94,9 +94,11 @@ def plot_meridional_avg_climo (indir,
 
     ref_plot_field = ref_meridional_avg
 
-    if debug: print __name__, 'ref_plot_field.shape ', ref_plot_field.shape
+    if debug:
+        print(__name__, 'ref_plot_field.shape ', ref_plot_field.shape)
 
-    if debug: print __name__, 'plot_field: ', plot_field
+    if debug:
+        print(__name__, 'plot_field: ', plot_field)
 
     plot_field_mean = numpy.mean(plot_field, axis = 0)
     ref_plot_field_mean = numpy.mean(ref_plot_field, axis = 0)
@@ -127,11 +129,11 @@ def plot_meridional_avg_climo (indir,
 
     ax.axis([lon_reg[0],lon_reg[-1], y_axis_ll, y_axis_ul])
 
-    print 'lon_reg[0],lon_reg[-1], 1.1*min_plot, 1.1*max_plot: ', \
-        lon_reg[0],lon_reg[-1], 1.1*min_plot, 1.1*max_plot
+    print('lon_reg[0],lon_reg[-1], 1.1*min_plot, 1.1*max_plot: ',
+          lon_reg[0],lon_reg[-1], 1.1*min_plot, 1.1*max_plot)
 
-    print 'lon_reg.shape, plot_field.shape, ref_plot_field.shape: ', \
-        lon_reg.shape, plot_field.shape, ref_plot_field.shape
+    print('lon_reg.shape, plot_field.shape, ref_plot_field.shape: ',
+          lon_reg.shape, plot_field.shape, ref_plot_field.shape)
 
     test_line, = ax.plot(lon_reg, plot_field, color = 'green', linewidth = 2.0, label = casename)
     ref_line, = ax.plot(lon_reg, ref_plot_field, color = 'black', linewidth = 2.0, label = ref_case)
@@ -141,7 +143,7 @@ def plot_meridional_avg_climo (indir,
     ax.set_title(field_name, fontsize = 12)
 
     #ax.get_yaxis().get_major_formatter().set_useOffset(False)
-    print __name__, 'levels:', levels
+    print(__name__, 'levels:', levels)
     ax.yaxis.set_major_locator(FixedLocator(levels))
 
     for tick in ax.yaxis.get_major_ticks():
@@ -241,7 +243,7 @@ if __name__ == "__main__":
     colors = ['b', 'g', 'r', 'c', 'm', 'y']
 
     x = mpl.get_backend()
-    print 'backend: ', x
+    print('backend: ', x)
 
     plot_meridional_avg_climo(indir = indir,
                               casename = casename,

--- a/python/plot_meridional_avg_multiple_fields_climo.py
+++ b/python/plot_meridional_avg_multiple_fields_climo.py
@@ -8,6 +8,8 @@
 ###Work in Progress: Plot meridional averages for different fields in the same plot.
 ###07/03/2017
 
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import matplotlib as mpl
 #changing the default backend to agg to resolve contouring issue on rhea
 mpl.use('Agg')

--- a/python/plot_meridional_avg_multiple_fields_climo.py
+++ b/python/plot_meridional_avg_multiple_fields_climo.py
@@ -51,7 +51,7 @@ def plot_meridional_avg_multiple_fields_climo (indir,
 
 
     for i,field_name in enumerate(field_names):
-        print __name__, 'casename: ', casename
+        print(__name__, 'casename: ', casename)
         meridional_avg, lon_reg, units = get_reg_meridional_avg_climo (
                                   indir     = indir,
                                   casename     = casename,
@@ -100,10 +100,12 @@ def plot_meridional_avg_multiple_fields_climo (indir,
 
         ref_plot_field[i, :] = ref_meridional_avg
 
-        if debug: print __name__, 'ref_plot_field.shape ', ref_plot_field.shape
+        if debug:
+            print(__name__, 'ref_plot_field.shape ', ref_plot_field.shape)
 
 
-        if debug: print __name__, 'plot_field: ', plot_field
+        if debug:
+            print(__name__, 'plot_field: ', plot_field)
 
     plot_field_mean = numpy.mean(plot_field, axis = 1)
     ref_plot_field_mean = numpy.mean(ref_plot_field, axis = 1)
@@ -131,8 +133,8 @@ def plot_meridional_avg_multiple_fields_climo (indir,
 
         ax[i].axis([lon_reg[0],lon_reg[-1], y_axis_ll, y_axis_ul])
 
-        print 'lon_reg[0],lon_reg[-1], 1.1*min_plot, 1.1*max_plot: ', \
-            lon_reg[0],lon_reg[-1], 1.1*min_plot, 1.1*max_plot
+        print('lon_reg[0],lon_reg[-1], 1.1*min_plot, 1.1*max_plot: ',
+              lon_reg[0],lon_reg[-1], 1.1*min_plot, 1.1*max_plot)
 
 
 
@@ -247,7 +249,7 @@ if __name__ == "__main__":
     colors = ['b', 'g', 'r', 'c', 'm', 'y']
 
     x = mpl.get_backend()
-    print 'backend: ', x
+    print('backend: ', x)
 
     plot_meridional_avg_multiple_fields_climo(
             indir = indir,

--- a/python/plot_meridional_avg_reg_seasonal_cycle.py
+++ b/python/plot_meridional_avg_reg_seasonal_cycle.py
@@ -7,6 +7,8 @@
 #
 #Not ready yet (07/18/2017: Salil)
 
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import matplotlib as mpl
 
 

--- a/python/plot_meridional_avg_reg_seasonal_cycle.py
+++ b/python/plot_meridional_avg_reg_seasonal_cycle.py
@@ -54,7 +54,7 @@ def plot_meridional_avg_reg_seasonal_cycle(indir,
                debug = False):
 
 
-    print __name__, 'casename: ', casename
+    print(__name__, 'casename: ', casename)
 
     for month in range(0, 11):
         meridional_avg, lon_reg, units = get_reg_meridional_avg_climo (
@@ -100,9 +100,11 @@ def plot_meridional_avg_reg_seasonal_cycle(indir,
         ref_meridional_avg_all_months[:, month] = ref_meridional_avg
 
 
-    if debug: print __name__, 'ref_plot_field.shape ', ref_plot_field.shape
+    if debug:
+        print(__name__, 'ref_plot_field.shape ', ref_plot_field.shape)
 
-    if debug: print __name__, 'plot_field: ', plot_field
+    if debug:
+        print(__name__, 'plot_field: ', plot_field)
 
     season = get_season_name(begin_month, end_month)
 
@@ -245,7 +247,7 @@ if __name__ == "__main__":
     colors = ['b', 'g', 'r', 'c', 'm', 'y']
 
     x = mpl.get_backend()
-    print 'backend: ', x
+    print('backend: ', x)
 
     plot_meridional_avg_climo(indir = indir,
                               casename = casename,

--- a/python/plot_multiple_index.py
+++ b/python/plot_multiple_index.py
@@ -6,6 +6,8 @@
 # in the LICENSE file in the top level a-prime directory
 #
 
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import matplotlib as mpl
 #changing the default backend to agg to resolve contouring issue on rhea
 mpl.use('Agg')

--- a/python/plot_multiple_index.py
+++ b/python/plot_multiple_index.py
@@ -176,13 +176,13 @@ def plot_multiple_index   (indir,
 
             if begin_month == 0 and end_month == 11 and aggregate == 0:
                 bw   = 13
-                wgts = numpy.ones(bw)/bw
-                nyrs = nt/n_months_season
+                wgts = numpy.ones(bw) // bw
+                nyrs = nt // n_months_season
 
 
                 plot_ts_moving_avg = numpy.convolve(plot_ts[i, :], wgts, 'valid')
 
-                smooth_line, = ax[i, k].plot(plot_time[bw/2:-bw/2+1], plot_ts_moving_avg,
+                smooth_line, = ax[i, k].plot(plot_time[bw // 2:-bw // 2+1], plot_ts_moving_avg,
                                 color = colors[i],
                                 linewidth = 2.0,
                                 label = 'Moving avg. (Bandwidth = ' + "%3d" % bw + ' months)')

--- a/python/plot_multiple_index.py
+++ b/python/plot_multiple_index.py
@@ -58,7 +58,7 @@ def plot_multiple_index   (indir,
     n_reg = len(regs)
 
     for i,reg in enumerate(regs):
-        print __name__, 'casename: ', casename
+        print(__name__, 'casename: ', casename)
         area_seasonal_avg, n_months_season, units = get_reg_seasonal_avg (
                                   indir     = indir,
                                   casename     = casename,
@@ -86,11 +86,12 @@ def plot_multiple_index   (indir,
             test_plot_ts[i, :] = area_seasonal_avg_stddize
 
 
-        if debug: print __name__, 'test_plot_ts: ', test_plot_ts
+        if debug:
+            print(__name__, 'test_plot_ts: ', test_plot_ts)
 
 
     for i,reg in enumerate(regs):
-        print __name__, 'casename: ', casename
+        print(__name__, 'casename: ', casename)
         area_seasonal_avg, n_months_season, units = get_reg_seasonal_avg (
                                   indir     = ref_case_dir,
                                   casename     = ref_case,
@@ -118,7 +119,8 @@ def plot_multiple_index   (indir,
             ref_plot_ts[i, :] = area_seasonal_avg_stddize
 
 
-        if debug: print __name__, 'test_plot_ts: ', test_plot_ts
+        if debug:
+            print(__name__, 'test_plot_ts: ', test_plot_ts)
 
 
     f, ax = plt.subplots(n_reg, 2, figsize=(11,8.5))
@@ -149,8 +151,10 @@ def plot_multiple_index   (indir,
         else:
             plot_time = numpy.arange(0,nt)
 
-        if debug: print __name__, 'plot_time: ', plot_time
-        if debug: print __name__, 'plot_begin_yr: ', plot_begin_yr
+        if debug:
+            print(__name__, 'plot_time: ', plot_time)
+        if debug:
+            print(__name__, 'plot_begin_yr: ', plot_begin_yr)
 
         plot_ts_mean   = numpy.mean(plot_ts, axis = 1)
         plot_ts_stddev = numpy.std(plot_ts, axis = 1)
@@ -164,8 +168,8 @@ def plot_multiple_index   (indir,
 
             ax[i, k].axis([plot_time[0],plot_time[-1], y_axis_ll, y_axis_ul])
 
-            print 'plot_time[0],plot_time[-1], 1.1*min_plot, 1.1*max_plot: ', \
-                plot_time[0],plot_time[-1], 1.1*min_plot, 1.1*max_plot
+            print('plot_time[0],plot_time[-1], 1.1*min_plot, 1.1*max_plot: ',
+                  plot_time[0],plot_time[-1], 1.1*min_plot, 1.1*max_plot)
 
             mean_line_plot = numpy.zeros(nt) + plot_ts_mean[i]
             mean_line, = ax[i, k].plot(plot_time, mean_line_plot, color = 'black', linewidth = 1.0, label = 'Mean')
@@ -336,13 +340,13 @@ if __name__ == "__main__":
     #regs = ['global', 'NH_high_lats', 'NH_mid_lats', 'tropics', 'SH_mid_lats', 'SH_high_lats']
     #names = ['Global', '90N-50N', '50N-20N', '20N-20S', '20S-50S', '50S-90S']
 
-    print 'salil', regs
-    print 'salil', names
+    print('salil', regs)
+    print('salil', names)
 
     colors = ['b', 'g', 'r', 'c', 'm', 'y']
 
     x = mpl.get_backend()
-    print 'backend: ', x
+    print('backend: ', x)
 
     plot_multiple_index(indir = indir,
                         casename = casename,

--- a/python/plot_multiple_index_same_plot.py
+++ b/python/plot_multiple_index_same_plot.py
@@ -166,13 +166,13 @@ def plot_multiple_index_same_plot   (indir,
 
             if begin_month == 0 and end_month == 11 and aggregate[i] == 0:
                 bw   = 13
-                wgts = numpy.ones(bw)/bw
-                nyrs = nt/n_months_season
+                wgts = numpy.ones(bw) // bw
+                nyrs = nt // n_months_season
 
 
                 plot_ts_moving_avg = numpy.convolve(plot_ts[i, :], wgts, 'valid')
 
-                smooth_line, = ax[i, k].plot(plot_time[bw/2:-bw/2+1], plot_ts_moving_avg,
+                smooth_line, = ax[i, k].plot(plot_time[bw // 2:-bw // 2+1], plot_ts_moving_avg,
                                 color = colors[i],
                                 linewidth = 2.0,
                                 label = 'Moving avg. (Bandwidth = ' + "%3d" % bw + ' months)')

--- a/python/plot_multiple_index_same_plot.py
+++ b/python/plot_multiple_index_same_plot.py
@@ -6,6 +6,8 @@
 # in the LICENSE file in the top level a-prime directory
 #
 
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import matplotlib as mpl
 #changing the default backend to agg to resolve contouring issue on rhea
 mpl.use('Agg')

--- a/python/plot_multiple_index_same_plot.py
+++ b/python/plot_multiple_index_same_plot.py
@@ -59,7 +59,7 @@ def plot_multiple_index_same_plot   (indir,
     n_index = len(index_names)
 
     for i,index_name in enumerate(index_names):
-        print __name__, 'casename: ', casename
+        print(__name__, 'casename: ', casename)
         index_temp, units = read_index_file (
                                   indir     = indir[i],
                                   casename     = casename[i],
@@ -81,12 +81,12 @@ def plot_multiple_index_same_plot   (indir,
         test_plot_ts[i, :] = index_temp
 
 
-        if debug: print __name__, 'test_plot_ts: ', test_plot_ts
+        if debug: print(__name__, 'test_plot_ts: ', test_plot_ts)
 
     test_corr_matrix = numpy.corrcoef(test_plot_ts)
 
     for i,index_name in enumerate(index_names):
-        print __name__, 'casename: ', casename
+        print(__name__, 'casename: ', casename)
         index_temp, units = read_index_file (
                               indir     = ref_case_dir[i],
                               casename     = ref_case[i],
@@ -108,7 +108,7 @@ def plot_multiple_index_same_plot   (indir,
         ref_plot_ts[i, :] = index_temp
 
 
-        if debug: print __name__, 'ref_plot_ts: ', ref_plot_ts
+        if debug: print(__name__, 'ref_plot_ts: ', ref_plot_ts)
 
     ref_corr_matrix = numpy.corrcoef(ref_plot_ts)
 
@@ -143,8 +143,8 @@ def plot_multiple_index_same_plot   (indir,
         else:
             plot_time = numpy.arange(0,nt)
 
-        if debug: print __name__, 'plot_time: ', plot_time
-        if debug: print __name__, 'plot_begin_yr: ', plot_begin_yr
+        if debug: print(__name__, 'plot_time: ', plot_time)
+        if debug: print(__name__, 'plot_begin_yr: ', plot_begin_yr)
 
         plot_ts_mean   = numpy.mean(plot_ts, axis = 1)
         plot_ts_stddev = numpy.std(plot_ts, axis = 1)
@@ -158,8 +158,8 @@ def plot_multiple_index_same_plot   (indir,
 
             ax[i, k].axis([plot_time[0],plot_time[-1], y_axis_ll, y_axis_ul])
 
-            print 'plot_time[0],plot_time[-1], 1.1*min_plot, 1.1*max_plot: ', \
-                plot_time[0],plot_time[-1], 1.1*min_plot, 1.1*max_plot
+            print('plot_time[0],plot_time[-1], 1.1*min_plot, 1.1*max_plot: ',
+                  plot_time[0],plot_time[-1], 1.1*min_plot, 1.1*max_plot)
 
             mean_line_plot = numpy.zeros(nt) + plot_ts_mean[i]
             mean_line, = ax[i, k].plot(plot_time, mean_line_plot, color = 'black', linewidth = 1.0, label = 'Mean')
@@ -207,7 +207,7 @@ def plot_multiple_index_same_plot   (indir,
                 if name != name_corr:
                     corr_text = 'Corr (' + name + ', ' + index_names[j] + '): ' + corr_str[j] + ' \n'
 
-            print __name__, 'corr_text: ', corr_text
+            print(__name__, 'corr_text: ', corr_text)
 
             ax[i, k].text(0.05, 0.90, corr_text, ha='left', \
                                                 fontsize = 8, transform=ax[i, k].transAxes)
@@ -242,7 +242,7 @@ def plot_multiple_index_same_plot   (indir,
 
     outfile = plots_dir + '/' + casename[0] + '_' + season + '_' + index_names_text + '.png'
 
-    print __name__, 'Plot file: ', outfile
+    print(__name__, 'Plot file: ', outfile)
 
     plt.savefig(outfile)
     #plt.show()
@@ -343,7 +343,7 @@ if __name__ == "__main__":
     colors = ['b', 'g', 'r', 'c', 'm', 'y']
 
     x = mpl.get_backend()
-    print 'backend: ', x
+    print('backend: ', x)
 
     plot_multiple_index_same_plot(indir = indir,
                                   casename = casename,

--- a/python/plot_multiple_index_seasonality.py
+++ b/python/plot_multiple_index_seasonality.py
@@ -6,6 +6,8 @@
 # in the LICENSE file in the top level a-prime directory
 #
 
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import matplotlib as mpl
 #changing the default backend to agg to resolve contouring issue on rhea
 mpl.use('Agg')

--- a/python/plot_multiple_index_seasonality.py
+++ b/python/plot_multiple_index_seasonality.py
@@ -77,7 +77,7 @@ def plot_multiple_index_seasonality   (indir,
         if i == 0:
             test_ts = numpy.zeros((n_reg, area_seasonal_avg.shape[0]))
             test_stddev_ts = numpy.zeros((n_reg, 12))
-            nyrs = area_seasonal_avg.shape[0]/12
+            nyrs = area_seasonal_avg.shape[0] // 12
 
         test_ts[i, :] = area_seasonal_avg
 
@@ -115,7 +115,7 @@ def plot_multiple_index_seasonality   (indir,
         if i == 0:
             ref_ts = numpy.zeros((n_reg, area_seasonal_avg.shape[0]))
             ref_stddev_ts = numpy.zeros((n_reg, 12))
-            nyrs = area_seasonal_avg.shape[0]/12
+            nyrs = area_seasonal_avg.shape[0] // 12
 
         ref_ts[i, :] = area_seasonal_avg
 

--- a/python/plot_multiple_index_seasonality.py
+++ b/python/plot_multiple_index_seasonality.py
@@ -59,7 +59,7 @@ def plot_multiple_index_seasonality   (indir,
     n_reg = len(regs)
 
     for i,reg in enumerate(regs):
-        print __name__, 'casename: ', casename
+        print(__name__, 'casename: ', casename)
         area_seasonal_avg, n_months_season, units = get_reg_seasonal_avg (
                                   indir     = indir,
                                   casename     = casename,
@@ -81,19 +81,22 @@ def plot_multiple_index_seasonality   (indir,
 
         test_ts[i, :] = area_seasonal_avg
 
-        if debug: print __name__, 'test_stddev_ts.shape: ', test_stddev_ts.shape
-        if debug: print __name__, 'nyrs: ', nyrs
+        if debug:
+            print(__name__, 'test_stddev_ts.shape: ', test_stddev_ts.shape)
+        if debug:
+            print(__name__, 'nyrs: ', nyrs)
 
         for month in range(0, 12):
             j = numpy.arange(0,nyrs) * 12 + month
             test_stddev_ts[i, month] = numpy.std(test_ts[i, j])
 
 
-        if debug: print __name__, 'test_ts: ', test_ts
+        if debug:
+            print(__name__, 'test_ts: ', test_ts)
 
 
     for i,reg in enumerate(regs):
-        print __name__, 'casename: ', casename
+        print(__name__, 'casename: ', casename)
         area_seasonal_avg, n_months_season, units = get_reg_seasonal_avg (
                                   indir     = ref_case_dir,
                                   casename     = ref_case,
@@ -120,7 +123,8 @@ def plot_multiple_index_seasonality   (indir,
             j = numpy.arange(0,nyrs) * 12 + month
             ref_stddev_ts[i, month] = numpy.std(ref_ts[i, j])
 
-        if debug: print __name__, 'ref_stddev_ts: ', ref_stddev_ts
+        if debug:
+            print(__name__, 'ref_stddev_ts: ', ref_stddev_ts)
 
 
     f, ax = plt.subplots(n_reg, 1, figsize=(4,8.5))
@@ -143,8 +147,8 @@ def plot_multiple_index_seasonality   (indir,
 
         ax[i].axis([plot_time[0],plot_time[-1], y_axis_ll, y_axis_ul])
 
-        print 'plot_time[0],plot_time[-1], y_axis_ll, y_axis_ul: ', \
-            plot_time[0],plot_time[-1], y_axis_ll, y_axis_ul
+        print('plot_time[0],plot_time[-1], y_axis_ll, y_axis_ul: ',
+              plot_time[0],plot_time[-1], y_axis_ll, y_axis_ul)
 
 
         test_plot, = ax[i].plot(plot_time, test_stddev_ts[i, :], color = colors[i], linewidth = 2.0, label = casename)
@@ -293,13 +297,13 @@ if __name__ == "__main__":
     #regs = ['global', 'NH_high_lats', 'NH_mid_lats', 'tropics', 'SH_mid_lats', 'SH_high_lats']
     #names = ['Global', '90N-50N', '50N-20N', '20N-20S', '20S-50S', '50S-90S']
 
-    print 'salil', regs
-    print 'salil', names
+    print('salil', regs)
+    print('salil', names)
 
     colors = ['b', 'g', 'r', 'c', 'm', 'y']
 
     x = mpl.get_backend()
-    print 'backend: ', x
+    print('backend: ', x)
 
     plot_multiple_index_seasonality(indir = indir,
                                     casename = casename,

--- a/python/plot_multiple_reg_seasonal_avg.py
+++ b/python/plot_multiple_reg_seasonal_avg.py
@@ -53,7 +53,7 @@ def plot_multiple_reg_seasonal_avg (indir,
 
 
     for i,reg in enumerate(regs):
-        print __name__, 'casename: ', casename
+        print(__name__, 'casename: ', casename)
         area_seasonal_avg, n_months_season, units = get_reg_seasonal_avg (
                                   indir     = indir,
                                   casename     = casename,
@@ -100,14 +100,16 @@ def plot_multiple_reg_seasonal_avg (indir,
 
         ref_plot_ts[i, :] = numpy.tile(ref_area_seasonal_avg, area_seasonal_avg.shape[0])
 
-        if debug: print __name__, 'ref_plot_ts.shape ', ref_plot_ts.shape
+        if debug:
+            print(__name__, 'ref_plot_ts.shape ', ref_plot_ts.shape)
 
 
-        if debug: print __name__, 'plot_ts: ', plot_ts
+        if debug:
+            print(__name__, 'plot_ts: ', plot_ts)
 
     plot_ts_mean = numpy.mean(plot_ts, axis = 1)
 
-    print __name__, 'int(math.ceil(n_reg/2)):', int(math.ceil(n_reg/2))
+    print(__name__, 'int(math.ceil(n_reg/2)):', int(math.ceil(n_reg/2)))
 
     f, ax = plt.subplots(int(math.ceil(n_reg/2)), 2, sharex = True, figsize=(8.5,11))
 
@@ -130,7 +132,7 @@ def plot_multiple_reg_seasonal_avg (indir,
 
     for i,name in enumerate(names):
         j = numpy.unravel_index(i, ax.shape)
-        print __name__, 'i and unraveled index, j: ', i, j
+        print(__name__, 'i and unraveled index, j: ', i, j)
 
         min_plot = min(numpy.amin(plot_ts[i, :]), ref_plot_ts[i, 0])
         max_plot = max(numpy.amax(plot_ts[i, :]), ref_plot_ts[i, 0])
@@ -145,8 +147,8 @@ def plot_multiple_reg_seasonal_avg (indir,
 
         ax[j].axis([plot_time[0],plot_time[-1], y_axis_ll, y_axis_ul])
 
-        print 'plot_time[0],plot_time[-1], 1.1*min_plot, 1.1*max_plot: ', \
-            plot_time[0],plot_time[-1], 1.1*min_plot, 1.1*max_plot
+        print('plot_time[0],plot_time[-1], 1.1*min_plot, 1.1*max_plot: ',
+              plot_time[0],plot_time[-1], 1.1*min_plot, 1.1*max_plot)
 
         if begin_month == 0 and end_month == 11 and aggregate == 0:
             bw   = 13
@@ -271,13 +273,13 @@ if __name__ == "__main__":
     #regs = ['global', 'NH_high_lats', 'NH_mid_lats', 'tropics', 'SH_mid_lats', 'SH_high_lats']
     #names = ['Global', '90N-50N', '50N-20N', '20N-20S', '20S-50S', '50S-90S']
 
-    print 'salil', regs
-    print 'salil', names
+    print('salil', regs)
+    print('salil', names)
 
     colors = ['b', 'g', 'r', 'c', 'm', 'y']
 
     x = mpl.get_backend()
-    print 'backend: ', x
+    print('backend: ', x)
 
     plot_multiple_reg_seasonal_avg(indir = indir,
                                    casename = casename,

--- a/python/plot_multiple_reg_seasonal_avg.py
+++ b/python/plot_multiple_reg_seasonal_avg.py
@@ -6,6 +6,8 @@
 # in the LICENSE file in the top level a-prime directory
 #
 
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import matplotlib as mpl
 #changing the default backend to agg to resolve contouring issue on rhea
 mpl.use('Agg')

--- a/python/plot_multiple_reg_seasonal_avg.py
+++ b/python/plot_multiple_reg_seasonal_avg.py
@@ -109,9 +109,9 @@ def plot_multiple_reg_seasonal_avg (indir,
 
     plot_ts_mean = numpy.mean(plot_ts, axis = 1)
 
-    print(__name__, 'int(math.ceil(n_reg/2)):', int(math.ceil(n_reg/2)))
+    print(__name__, 'int(math.ceil(n_reg/2)):', int(math.ceil(n_reg // 2)))
 
-    f, ax = plt.subplots(int(math.ceil(n_reg/2)), 2, sharex = True, figsize=(8.5,11))
+    f, ax = plt.subplots(int(math.ceil(n_reg // 2)), 2, sharex = True, figsize=(8.5,11))
 
     nt = area_seasonal_avg.shape[0]
 
@@ -152,12 +152,12 @@ def plot_multiple_reg_seasonal_avg (indir,
 
         if begin_month == 0 and end_month == 11 and aggregate == 0:
             bw   = 13
-            wgts = numpy.ones(bw)/bw
-            nyrs = nt/n_months_season
+            wgts = numpy.ones(bw) // bw
+            nyrs = nt // n_months_season
 
             plot_ts_moving_avg = numpy.convolve(plot_ts[i, :], wgts, 'valid')
 
-            ax[j].plot(plot_time[bw/2:-bw/2+1], plot_ts_moving_avg, color = colors[i], linewidth = 4.0)
+            ax[j].plot(plot_time[bw // 2:-bw // 2+1], plot_ts_moving_avg, color = colors[i], linewidth = 4.0)
             ax[j].plot(plot_time, plot_ts[i, :], color = colors[i], linewidth = 1.0)
             ax[j].plot(plot_time, ref_plot_ts[i, :], color = 'black', linewidth = 1.0)
             ax[j].set_xticks(numpy.arange(0, nt, 12))

--- a/python/plot_reg_seasonal_avg.py
+++ b/python/plot_reg_seasonal_avg.py
@@ -6,6 +6,8 @@
 # in the LICENSE file in the top level a-prime directory
 #
 
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import matplotlib as mpl
 #changing the default backend to agg to resolve contouring issue on rhea
 mpl.use('Agg')

--- a/python/plot_reg_seasonal_avg.py
+++ b/python/plot_reg_seasonal_avg.py
@@ -50,7 +50,7 @@ def plot_reg_seasonal_avg (casename,
                   aggregate = aggregate,
                   debug = debug)
 
-    print __name__, 'area_seasonal_avg.shape', area_seasonal_avg.shape
+    print(__name__, 'area_seasonal_avg.shape', area_seasonal_avg.shape)
 
     #plt.subplot(3,1,1)
 

--- a/python/plot_regress_index_field.py
+++ b/python/plot_regress_index_field.py
@@ -58,8 +58,8 @@ def plot_regress_index_field (indir,
                debug = False):
 
 
-    print __name__, 'casename: ', casename
-    print __name__, 'field_name: ', field_name
+    print(__name__, 'casename: ', casename)
+    print(__name__, 'field_name: ', field_name)
 
     regr_matrix, corr_matrix, t_test_matrix, lat_reg, lon_reg, units = get_regress_index_field (
                               indir     = indir,
@@ -86,7 +86,8 @@ def plot_regress_index_field (indir,
             if ref_case[k] == 'HadISST' or ref_case[k] == 'HadISST_ts' or ref_case[k] == 'HadOIBl':
                     if field_name[k] == 'TS': field_name_ref[k] = 'SST'
 
-    if debug: print __name__, 'field_name_ref: ', field_name_ref
+    if debug:
+        print(__name__, 'field_name_ref: ', field_name_ref)
 
 
     ref_regr_matrix, ref_corr_matrix, ref_t_test_matrix, lat_reg, lon_reg, units = get_regress_index_field (
@@ -118,11 +119,12 @@ def plot_regress_index_field (indir,
     max_plot = round_to_first(5.0 * numpy.nanstd(ref_regr_matrix))
     levels      = numpy.linspace(-max_plot, max_plot, num = num)
 
-    print
-    print 'mean, stddev, max_plot: ', \
-        numpy.nanmean(ref_regr_matrix), numpy.nanstd(ref_regr_matrix), max_plot
-    print 'min, max: ', numpy.nanmin(ref_regr_matrix), numpy.nanmax(ref_regr_matrix)
-    print 'contour levels: ', levels
+    print()
+    print('mean, stddev, max_plot: ', numpy.nanmean(ref_regr_matrix),
+          numpy.nanstd(ref_regr_matrix), max_plot)
+    print('min, max: ', numpy.nanmin(ref_regr_matrix),
+          numpy.nanmax(ref_regr_matrix))
+    print('contour levels: ', levels)
 
 
 
@@ -359,7 +361,7 @@ if __name__ == "__main__":
     colors = ['b', 'g', 'r', 'c', 'm', 'y']
 
     x = mpl.get_backend()
-    print 'backend: ', x
+    print('backend: ', x)
 
     plot_regress_index_field(indir = indir,
                              casename = casename,

--- a/python/plot_regress_index_field.py
+++ b/python/plot_regress_index_field.py
@@ -5,6 +5,9 @@
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import matplotlib as mpl
 #changing the default backend to agg to resolve contouring issue on rhea
 mpl.use('Agg')

--- a/python/plot_regress_index_index.py
+++ b/python/plot_regress_index_index.py
@@ -61,8 +61,8 @@ def plot_regress_index_index (indir,
                debug = False):
 
 
-    print __name__, 'casename: ', casename
-    print __name__, 'field_name: ', field_name
+    print(__name__, 'casename: ', casename)
+    print(__name__, 'field_name: ', field_name)
 
     x = get_regress_index_index (indir     = indir,
                     casename     = casename,
@@ -123,7 +123,7 @@ def plot_regress_index_index (indir,
         if ref_case[k] == 'HadISST' or ref_case[k] == 'HadISST_ts' or ref_case[k] == 'HadOIBl':
             if field_name[k] == 'TS': field_name_ref[k] = 'SST'
 
-    if debug: print __name__, 'field_name_ref: ', field_name_ref
+    if debug: print(__name__, 'field_name_ref: ', field_name_ref)
 
 
     x = get_regress_index_index (      indir         = ref_case_dir,
@@ -261,8 +261,8 @@ def plot_regress_index_index (indir,
     mpl.rcParams['savefig.dpi']=300
 
 
-    print __name__, 'begin_month: ', begin_month
-    print __name__, 'end_month: ', end_month
+    print(__name__, 'begin_month: ', begin_month)
+    print(__name__, 'end_month: ', end_month)
 
     outfile = plots_dir + '/' + casename[0] + '-' + ref_case[0] + '_feedback_' \
                + field_name[0] + '_' + reg[0] + '_' + season_field + '_' \
@@ -376,7 +376,7 @@ if __name__ == "__main__":
     colors = ['b', 'g', 'r', 'c', 'm', 'y']
 
     x = mpl.get_backend()
-    print 'backend: ', x
+    print('backend: ', x)
 
     plot_regress_index_index (indir = indir,
                    casename = casename,

--- a/python/plot_regress_index_index.py
+++ b/python/plot_regress_index_index.py
@@ -5,6 +5,9 @@
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import matplotlib as mpl
 #changing the default backend to agg to resolve contouring issue on rhea
 mpl.use('Agg')

--- a/python/plot_regress_lead_lag_index_field.py
+++ b/python/plot_regress_lead_lag_index_field.py
@@ -58,8 +58,8 @@ def plot_regress_lead_lag_index_field (indir,
     print(__name__, 'casename: ', casename)
     print(__name__, 'field_name: ', field_name)
 
-    lags = range(-8, 12, 4)
-#    lags = range(-4, 4, 4)
+    lags = list(range(-8, 12, 4))
+#    lags = list(range(-4, 4, 4))
     n_lags = len(lags)
 
     for i, lag in enumerate(lags):

--- a/python/plot_regress_lead_lag_index_field.py
+++ b/python/plot_regress_lead_lag_index_field.py
@@ -55,8 +55,8 @@ def plot_regress_lead_lag_index_field (indir,
                debug = False):
 
 
-    print __name__, 'casename: ', casename
-    print __name__, 'field_name: ', field_name
+    print(__name__, 'casename: ', casename)
+    print(__name__, 'field_name: ', field_name)
 
     lags = range(-8, 12, 4)
 #    lags = range(-4, 4, 4)
@@ -101,7 +101,8 @@ def plot_regress_lead_lag_index_field (indir,
         if ref_case[k] == 'HadISST' or ref_case[k] == 'HadISST_ts' or ref_case[k] == 'HadOIBl':
             if field_name[k] == 'TS': field_name_ref[k] = 'SST'
 
-    if debug: print __name__, 'field_name_ref: ', field_name_ref
+    if debug:
+        print(__name__, 'field_name_ref: ', field_name_ref)
 
 
     for i, lag in enumerate(lags):
@@ -135,8 +136,10 @@ def plot_regress_lead_lag_index_field (indir,
         ref_plot_field = ref_regr_matrix_lag
         ref_plot_t_test = ref_t_test_matrix_lag
 
-        if debug: print __name__, 'plot_field: ', plot_field
-        if debug: print __name__, 'ref_plot_field: ', ref_plot_field
+        if debug:
+            print(__name__, 'plot_field: ', plot_field)
+        if debug:
+            print(__name__, 'ref_plot_field: ', ref_plot_field)
 
     season_field = get_season_name(begin_month[0], end_month[0])
     season_index = get_season_name(begin_month[1], end_month[1])
@@ -151,17 +154,19 @@ def plot_regress_lead_lag_index_field (indir,
     max_plot = round_to_first(5.0 * numpy.nanstd(ref_plot_field))
     levels      = numpy.linspace(-max_plot, max_plot, num = num)
 
-    print
-    print 'plot_field - mean, stddev: ', \
-        numpy.nanmean(plot_field), numpy.nanstd(plot_field)
-    print 'plot_field - min, max: ', numpy.ma.min(plot_field), numpy.ma.max(plot_field)
+    print()
+    print('plot_field - mean, stddev: ', numpy.nanmean(plot_field),
+          numpy.nanstd(plot_field))
+    print('plot_field - min, max: ', numpy.ma.min(plot_field),
+          numpy.ma.max(plot_field))
 
-    print 'ref_plot_field - mean, stddev: ', \
-        numpy.nanmean(ref_plot_field), numpy.nanstd(ref_plot_field)
-    print 'ref_plot_field - min, max: ', numpy.nanmin(plot_field), numpy.nanmax(plot_field)
+    print('ref_plot_field - mean, stddev: ', numpy.nanmean(ref_plot_field),
+          numpy.nanstd(ref_plot_field))
+    print('ref_plot_field - min, max: ', numpy.nanmin(plot_field),
+          numpy.nanmax(plot_field))
 
-    print 'max_plot: ', max_plot
-    print 'contour levels: ', levels
+    print('max_plot: ', max_plot)
+    print('contour levels: ', levels)
 
 
     #PLOT REGRESSIONS
@@ -243,8 +248,8 @@ def plot_regress_lead_lag_index_field (indir,
     mpl.rcParams['savefig.dpi']=300
 
 
-    print __name__, 'begin_month: ', begin_month
-    print __name__, 'end_month: ', end_month
+    print(__name__, 'begin_month: ', begin_month)
+    print(__name__, 'end_month: ', end_month)
 
     outfile = plots_dir + '/' + casename[0] + '_ENSO_evolution_regr_' \
                + field_name[0] + '_' + reg[0] + '_' + season_field + '_' \
@@ -332,8 +337,8 @@ def plot_regress_lead_lag_index_field (indir,
     mpl.rcParams['savefig.dpi']=300
 
 
-    print __name__, 'begin_month: ', begin_month
-    print __name__, 'end_month: ', end_month
+    print(__name__, 'begin_month: ', begin_month)
+    print(__name__, 'end_month: ', end_month)
 
     outfile = plots_dir + '/' + casename[0] + '_ENSO_evolution_corr_' \
                + field_name[0] + '_' + reg[0] + '_' + season_field + '_' \
@@ -439,7 +444,7 @@ if __name__ == "__main__":
     colors = ['b', 'g', 'r', 'c', 'm', 'y']
 
     x = mpl.get_backend()
-    print 'backend: ', x
+    print('backend: ', x)
 
     plot_regress_lead_lag_index_field (indir = indir,
                    casename = casename,

--- a/python/plot_regress_lead_lag_index_field.py
+++ b/python/plot_regress_lead_lag_index_field.py
@@ -5,6 +5,9 @@
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import matplotlib as mpl
 #changing the default backend to agg to resolve contouring issue on rhea
 mpl.use('Agg')

--- a/python/plot_stddev.py
+++ b/python/plot_stddev.py
@@ -6,6 +6,8 @@
 # in the LICENSE file in the top level a-prime directory
 #
 
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import matplotlib as mpl
 #changing the default backend to agg to resolve contouring issue on rhea
 mpl.use('Agg')

--- a/python/plot_stddev.py
+++ b/python/plot_stddev.py
@@ -108,9 +108,9 @@ debug            = options.debug
 #Get filename
 season = get_season_name(begin_month, end_month)
 
-print
-print 'Computing climo and inter-annual std. dev. for case: ', casename
-print
+print()
+print('Computing climo and inter-annual std. dev. for case: ', casename)
+print()
 
 field_mean, field_stddev, lat, lon, units = compute_reg_seasonal_climo_and_stddev(
                                 indir = indir,
@@ -153,7 +153,7 @@ ref_field_mean, ref_field_stddev, lat, lon, units = compute_reg_seasonal_climo_a
 #                     reg = 'global')
 #
 #print
-#print 'Reading climo file for case: ', ref_case
+#print('Reading climo file for case: ', ref_case
 #print
 #
 #field_ref_case, lat, lon, area, units = read_climo_file(indir = ref_case_dir, \
@@ -334,12 +334,12 @@ plt.subplots_adjust(hspace=0.25)
 #max_plot    = round_to_first(4.0 * numpy.ma.std(field_diff))
 #levels_diff = numpy.linspace(-max_plot, max_plot, num = num)
 #
-#print
-#print 'For difference plot: '
-#print 'mean, stddev, max_plot: ', \
-#        numpy.ma.mean(field_diff), numpy.ma.std(field_diff), max_plot
-#print 'min, max: ', numpy.ma.min(field_diff), numpy.ma.max(field_diff)
-#print 'contour levels: ', levels_diff
+#print()
+#print('For difference plot: ')
+#print('mean, stddev, max_plot: ',
+#      numpy.ma.mean(field_diff), numpy.ma.std(field_diff), max_plot)
+#print('min, max: ', numpy.ma.min(field_diff), numpy.ma.max(field_diff))
+#print('contour levels: ', levels_diff)
 #
 ##Plot difference plot
 #ax = f.add_subplot(3,1,3)

--- a/python/read_and_plot_index_for_cases.py
+++ b/python/read_and_plot_index_for_cases.py
@@ -6,6 +6,8 @@
 # in the LICENSE file in the top level a-prime directory
 #
 
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import matplotlib as mpl
 #changing the default backend to agg to resolve contouring issue on rhea
 mpl.use('Agg')

--- a/python/read_and_plot_index_for_cases.py
+++ b/python/read_and_plot_index_for_cases.py
@@ -162,13 +162,13 @@ def read_and_plot_index_for_cases (indir,
 
         if begin_month == 0 and end_month == 11 and aggregate == 0:
             bw   = 13
-            wgts = numpy.ones(bw)/bw
-            nyrs = nt/n_months_season
+            wgts = numpy.ones(bw) // bw
+            nyrs = nt // n_months_season
 
 
             plot_ts_moving_avg = numpy.convolve(plot_ts, wgts, 'valid')
 
-            smooth_line, = ax[k].plot(plot_time[bw/2:-bw/2+1], plot_ts_moving_avg,
+            smooth_line, = ax[k].plot(plot_time[bw // 2:-bw // 2+1], plot_ts_moving_avg,
                             color = colors[i],
                             linewidth = 2.0,
                             label = 'Moving avg. (Bandwidth = ' + "%3d" % bw + ' months)')

--- a/python/read_and_plot_index_for_cases.py
+++ b/python/read_and_plot_index_for_cases.py
@@ -59,7 +59,7 @@ def read_and_plot_index_for_cases (indir,
 
     n_reg = len(regs)
 
-    print __name__, 'casename: ', casename
+    print(__name__, 'casename: ', casename)
     test_ts, units = read_index (      indir     = indir,
                       casename     = casename,
                       field_name     = field_name,
@@ -79,7 +79,8 @@ def read_and_plot_index_for_cases (indir,
         test_ts[i, :] = area_seasonal_avg_stddize
 
 
-        if debug: print __name__, 'test_ts: ', test_ts
+        if debug:
+            print(__name__, 'test_ts: ', test_ts)
 
 
     test_plot_ts = test_ts
@@ -137,8 +138,10 @@ def read_and_plot_index_for_cases (indir,
         else:
             plot_time = numpy.arange(0,nt)
 
-        if debug: print __name__, 'plot_time: ', plot_time
-        if debug: print __name__, 'plot_begin_yr: ', plot_begin_yr
+        if debug:
+            print(__name__, 'plot_time: ', plot_time)
+        if debug:
+            print(__name__, 'plot_begin_yr: ', plot_begin_yr)
 
         plot_ts_mean   = numpy.mean(plot_ts)
         plot_ts_stddev = numpy.std(plot_ts)
@@ -151,8 +154,8 @@ def read_and_plot_index_for_cases (indir,
 
         ax[k].axis([plot_time[0],plot_time[-1], y_axis_ll, y_axis_ul])
 
-        print 'plot_time[0],plot_time[-1], 1.1*min_plot, 1.1*max_plot: ', \
-            plot_time[0],plot_time[-1], 1.1*min_plot, 1.1*max_plot
+        print('plot_time[0],plot_time[-1], 1.1*min_plot, 1.1*max_plot: ',
+              plot_time[0],plot_time[-1], 1.1*min_plot, 1.1*max_plot)
 
         mean_line_plot = numpy.zeros(nt) + plot_ts_mean
         mean_line, = ax[k].plot(plot_time, mean_line_plot, color = 'black', linewidth = 1.0, label = 'Mean')
@@ -325,7 +328,7 @@ if __name__ == "__main__":
     colors = ['b', 'g', 'r', 'c', 'm', 'y']
 
     x = mpl.get_backend()
-    print 'backend: ', x
+    print('backend: ', x)
 
     read_and_plot_index_for_cases (indir = indir,
                    casename = casename,

--- a/python/read_climo_file.py
+++ b/python/read_climo_file.py
@@ -56,16 +56,17 @@ def read_climo_file (indir, \
 
     except:
 
-        print
-        print file_name, 'not found! Checking derived variables list for ', field_name
+        print()
+        print(file_name, 'not found! Checking derived variables list for ',
+              field_name)
 
         var_expr, var_expr_numpy = get_derived_var_expr(field_name)
 
         for i, field_name_temp in enumerate(var_expr.atoms(Symbol)):
 
-            print field_name_temp
+            print(field_name_temp)
             field_name_temp_str = str(field_name_temp)
-            print field_name_temp_str
+            print(field_name_temp_str)
 
             file_name_temp = get_climo_filename(     indir,
                                 casename,
@@ -80,7 +81,7 @@ def read_climo_file (indir, \
 
             field_temp = f.variables[field_name_temp_str]
 
-            print 'field_temp.shape: ', field_temp.shape
+            print('field_temp.shape: ', field_temp.shape)
 
             if i == 0:
                 field_list = [field_temp[:]]
@@ -98,14 +99,14 @@ def read_climo_file (indir, \
 
             f.close()
 
-        print
-        print 'field_list length: ', len(field_list)
+        print()
+        print('field_list length: ', len(field_list))
 
         field = var_expr_numpy(*field_list)
-        print __name__, 'field.shape: ', field.shape
+        print(__name__, 'field.shape: ', field.shape)
 
-    print __name__, 'field.shape: ', field.shape
-    print field
+    print(__name__, 'field.shape: ', field.shape)
+    print(field)
 
 
     nlon = lon.shape[0]
@@ -115,7 +116,7 @@ def read_climo_file (indir, \
     #Getting area tile from gw if "area" is not available in the climo file
 
     if 'gw' in locals():
-        print __name__, 'Computing area weights from gw'
+        print(__name__, 'Computing area weights from gw')
 
         area_tile = numpy.tile(gw[:], (nlon))
         area_transpose = numpy.reshape(area_tile, (nlon, nlat))
@@ -127,10 +128,11 @@ def read_climo_file (indir, \
 
     lat_ll, lat_ul, lon_ll, lon_ul = get_reg_box(reg)
 
-    print
-    print __name__, 'lat_ll, lat_ul, lon_ll, lon_ul: ', lat_ll, lat_ul, lon_ll, lon_ul
-    print __name__, 'lat: ', lat
-    print __name__, 'type(lat[:]): ', type(lat[:])
+    print()
+    print(__name__, 'lat_ll, lat_ul, lon_ll, lon_ul: ', lat_ll, lat_ul, lon_ll,
+          lon_ul)
+    print(__name__, 'lat: ', lat)
+    print(__name__, 'type(lat[:]): ', type(lat[:]))
 
     lat_reg_boolean = numpy.logical_and(lat[:]>=lat_ll, lat[:]<=lat_ul)
     lat_index_reg   = numpy.asarray(numpy.where(lat_reg_boolean))[0, :]
@@ -151,13 +153,13 @@ def read_climo_file (indir, \
     #lon_index = numpy.arange(0,nlon)
     #lon_index_reg = lon_index[lon_reg_boolean]
 
-    if debug: print
-    if debug: print __name__, 'lat_reg: ', lat_reg_boolean
-    if debug: print __name__, 'lon_reg: ', lon_reg_boolean
-    if debug: print __name__, 'lat_index_reg.shape: ', lat_index_reg.shape
-    if debug: print __name__, 'lat_index_reg: ', lat_index_reg
-    if debug: print __name__, 'lon_index_reg: ', lon_index_reg
-    if debug: print __name__, 'type(field): ', type(field)
+    if debug: print()
+    if debug: print(__name__, 'lat_reg: ', lat_reg_boolean)
+    if debug: print(__name__, 'lon_reg: ', lon_reg_boolean)
+    if debug: print(__name__, 'lat_index_reg.shape: ', lat_index_reg.shape)
+    if debug: print(__name__, 'lat_index_reg: ', lat_index_reg)
+    if debug: print(__name__, 'lon_index_reg: ', lon_index_reg)
+    if debug: print(__name__, 'type(field): ', type(field))
 
     #Mulitdimensional indexing with numpy require indexes to be multidimensional arrays
     #Used here only for derived variables like RESTOM
@@ -185,25 +187,26 @@ def read_climo_file (indir, \
         area_reg = area[lat_index_reg,lon_index_reg]
 
 
-    print __name__, "field_in.shape: ", field_in.shape
+    print(__name__, "field_in.shape: ", field_in.shape)
 
     if field_name[0:4] == 'PREC' and units == 'm/s':
-        print 'A precipitation field in m/s units! Changing units from m/s to mm/day!...'
+        print('A precipitation field in m/s units! Changing units from m/s to '
+              'mm/day!...')
         field_in = field_in * 86400.0 * 1000.0
         units = 'mm/day'
 
     if field_name[0:2] == 'TS' and units == 'K':
-        print 'A temperature field in K units! Changing units from K to C!...'
+        print('A temperature field in K units! Changing units from K to C!...')
         field_in = field_in - 273.15
         units = 'C'
 
     if field_name[0:3] == 'SST' and units == 'K':
-        print 'A temperature field in K units! Changing units from K to C!...'
+        print('A temperature field in K units! Changing units from K to C!...')
         field_in = field_in - 273.15
         units = 'C'
 
     if field_name[0:3] == 'TAU' and casename != 'ERS':
-        print 'Flipping sign of atm model wind stress values ...'
+        print('Flipping sign of atm model wind stress values ...')
         field_in = -field_in
 
     return field_in, lat_reg, lon_reg, area_reg, units

--- a/python/read_climo_file.py
+++ b/python/read_climo_file.py
@@ -5,6 +5,9 @@
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 from netCDF4 import Dataset
 from get_reg_box import get_reg_box
 from get_climo_filename import get_climo_filename

--- a/python/read_index_file.py
+++ b/python/read_index_file.py
@@ -5,6 +5,9 @@
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 from get_season_name import get_season_name
 from get_index_filename import get_index_filename
 from netCDF4 import Dataset

--- a/python/read_index_file.py
+++ b/python/read_index_file.py
@@ -42,7 +42,7 @@ def read_index_file (      indir,
                                           stdize        = stdize,
                                           debug         = debug)
 
-    print __name__, 'file_name: ', file_name
+    print(__name__, 'file_name: ', file_name)
 
     #try:
     f = Dataset(file_name, "r")
@@ -51,13 +51,13 @@ def read_index_file (      indir,
     units = field.units
 
     field_in = field[:]
-    print field.shape
-    print field_in.shape
+    print(field.shape)
+    print(field_in.shape)
 
     #except:
 
     #    print
-    #        print file_name, 'not found! Exiting'
+    #        print(file_name, 'not found! Exiting'
     #    quit()
 
 

--- a/python/read_monthly_data_ts.py
+++ b/python/read_monthly_data_ts.py
@@ -47,16 +47,17 @@ def read_monthly_data_ts(indir,
 
         except:
 
-            print
-            print field_name, 'not found! Checking derived variables list for ', field_name
+            print()
+            print(field_name, 'not found! Checking derived variables list '
+                  'for ', field_name)
 
             var_expr, var_expr_numpy = get_derived_var_expr(field_name)
 
             for i, field_name_temp in enumerate(var_expr.atoms(Symbol)):
 
-                print field_name_temp
+                print(field_name_temp)
                 field_name_temp_str = str(field_name_temp)
-                print field_name_temp_str
+                print(field_name_temp_str)
 
 
                 field_temp, lat, lon, area, units = read_monthly_data_ts_field(indir = indir,
@@ -76,11 +77,11 @@ def read_monthly_data_ts(indir,
                 else:
                     field_list.append(field_temp)
 
-            print
-            print 'field_list length: ', len(field_list)
+            print()
+            print('field_list length: ', len(field_list))
 
             field_in = var_expr_numpy(*field_list)
-            print __name__, 'field_in.shape: ', field_in.shape
+            print(__name__, 'field_in.shape: ', field_in.shape)
 
 
     elif field_name == 'PRECT':
@@ -100,9 +101,10 @@ def read_monthly_data_ts(indir,
 
 
         except:
-            print
-            print "Could not find file for: ", field_name, " Trying to look for PRECC and PRECL files!"
-            print
+            print()
+            print("Could not find file for: ", field_name,
+                  " Trying to look for PRECC and PRECL files!")
+            print()
 
             field_PRECC, lat, lon, area, units = read_monthly_data_ts_field(indir = indir,
                      casename = casename,
@@ -148,9 +150,10 @@ def read_monthly_data_ts(indir,
 
 
         except:
-            print
-            print "Could not find file for: ", field_name, " Trying to look for FSNT and FLNT files!"
-            print
+            print()
+            print("Could not find file for: ", field_name,
+                  " Trying to look for FSNT and FLNT files!")
+            print()
 
             field_FSNT, lat, lon, area, units = read_monthly_data_ts_field(indir = indir,
                  casename = casename,

--- a/python/read_monthly_data_ts.py
+++ b/python/read_monthly_data_ts.py
@@ -5,6 +5,10 @@
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
 from read_monthly_data_ts_field import read_monthly_data_ts_field
 from get_derived_var_expr import get_derived_var_expr
 

--- a/python/read_monthly_data_ts_field.py
+++ b/python/read_monthly_data_ts_field.py
@@ -28,7 +28,7 @@ def read_monthly_data_ts_field(indir,
     #Get filename
     #indir = '/lustre/atlas1/cli049/proj-shared/salil/archive/'
 
-    print indir, casename, interp_grid,interp_method, field_name
+    print(indir, casename, interp_grid,interp_method, field_name)
 
     if casename == 'COREv2' or casename == 'COREv2_flux' or casename == 'NCEP2' or casename == 'NCEP2_surface' or casename == 'HadISST_ts' or casename == 'HadOIBl':
         cam_text = '.'
@@ -49,7 +49,7 @@ def read_monthly_data_ts_field(indir,
             + interp_grid + '_' + \
             interp_method + '.' + field_name + '.' + str(begin_yr) + '-' + str(end_yr) +'.nc'
 
-    print "file_name: ", file_name
+    print("file_name: ", file_name)
 
 
     f = Dataset(file_name, "r")
@@ -75,17 +75,22 @@ def read_monthly_data_ts_field(indir,
 
         index_months_tile = numpy.tile(index_months_temp, nyrs-1)
 
-        if debug: print __name__, 'index_months_tile.shape: ', index_months_tile.shape
+        if debug:
+            print(__name__, 'index_months_tile.shape: ',
+                  index_months_tile.shape)
 
-        if debug: print __name__, 'index_months_tile: ', index_months_tile
+        if debug:
+            print(__name__, 'index_months_tile: ', index_months_tile)
 
         index_yr_temp = numpy.arange(nyrs) * 12
         index_yr_repeat = numpy.repeat(index_yr_temp, n_months_season)
 
         index_yr_repeat = index_yr_repeat[n_months_season_yr2:nyrs*n_months_season-n_months_season_yr1]
 
-        if debug: print __name__, 'index_yr_repeat.shape: ', index_yr_repeat.shape
-        if debug: print __name__, 'index_yr_repeat: ', index_yr_repeat
+        if debug:
+            print(__name__, 'index_yr_repeat.shape: ', index_yr_repeat.shape)
+        if debug:
+            print(__name__, 'index_yr_repeat: ', index_yr_repeat)
 
         index_time = index_months_tile + index_yr_repeat
 
@@ -96,25 +101,31 @@ def read_monthly_data_ts_field(indir,
 
         index_months_tile = numpy.tile(index_months_temp, nyrs)
 
-        if debug: print __name__, 'index_months_tile.shape: ', index_months_tile.shape
-        if debug: print __name__, 'index_months_tile: ', index_months_tile
+        if debug:
+            print(__name__, 'index_months_tile.shape: ',
+                  index_months_tile.shape)
+        if debug:
+            print(__name__, 'index_months_tile: ', index_months_tile)
 
 
         index_yr_temp = numpy.arange(nyrs) * 12
         index_yr_repeat = numpy.repeat(index_yr_temp, n_months_season)
 
-        if debug: print __name__, 'index_yr_repeat: ', index_yr_repeat
+        if debug:
+            print(__name__, 'index_yr_repeat: ', index_yr_repeat)
 
         index_time = index_months_tile + index_yr_repeat
 
-    if debug: print __name__, 'index_time: ', index_time
+    if debug:
+        print(__name__, 'index_time: ', index_time)
 
     nlon = lon.shape[0]
     nlat = lat.shape[0]
 
     lat_ll, lat_ul, lon_ll, lon_ul = get_reg_box(reg)
 
-    print __name__, 'lat_ll, lat_ul, lon_ll, lon_ul: ', lat_ll, lat_ul, lon_ll, lon_ul
+    print(__name__, 'lat_ll, lat_ul, lon_ll, lon_ul: ', lat_ll, lat_ul, lon_ll,
+          lon_ul)
 
     lat_reg_boolean = numpy.logical_and(lat[:]>=lat_ll, lat[:]<=lat_ul)
     lat_index_reg   = numpy.asarray(numpy.where(lat_reg_boolean))[0, :]
@@ -135,53 +146,58 @@ def read_monthly_data_ts_field(indir,
     #lon_index = numpy.arange(0,nlon)
     #lon_index_reg = lon_index[lon_reg_boolean]
 
-    if debug: print __name__, 'lat_reg: ', lat_reg_boolean
-    if debug: print __name__, 'lon_reg: ', lon_reg_boolean
-    if debug: print __name__, 'lat_index_reg.shape: ', lat_index_reg.shape
-    if debug: print __name__, 'lat_index_reg: ', lat_index_reg
-    if debug: print __name__, 'lon_index_reg: ', lon_index_reg
+    if debug: print(__name__, 'lat_reg: ', lat_reg_boolean)
+    if debug: print(__name__, 'lon_reg: ', lon_reg_boolean)
+    if debug: print(__name__, 'lat_index_reg.shape: ', lat_index_reg.shape)
+    if debug: print(__name__, 'lat_index_reg: ', lat_index_reg)
+    if debug: print(__name__, 'lon_index_reg: ', lon_index_reg)
 
-    if debug: print __name__, 'field[0, :, :]: ', field[0, :, :]
+    if debug: print(__name__, 'field[0, :, :]: ', field[0, :, :])
 
     field_in = field[index_time,lat_index_reg,lon_index_reg]
     area_reg = area[lat_index_reg, lon_index_reg]
 
-    print __name__, 'field.shape: ', field.shape
-    print __name__, 'field_in.shape: ', field_in.shape
-    print ''
+    print(__name__, 'field.shape: ', field.shape)
+    print(__name__, 'field_in.shape: ', field_in.shape)
+    print('')
 
     if field_name[0:4] == 'PREC' and field.units == 'm/s':
-        print 'A precipitation field in m/s units! Changing units from m/s to mm/day!...'
+        print('A precipitation field in m/s units! Changing units from m/s '
+              'to mm/day!...')
         field_in = field_in * 86400.0 * 1000.0
         units = 'mm/day'
 
     if field_name[0:2] == 'TS' and field.units == 'K':
-        print 'A temperature field in K units! Changing units from K to C!...'
+        print('A temperature field in K units! Changing units from K to C!...')
         field_in = field_in - 273.15
         units = 'C'
 
     if field_name[0:2] == 'TS' and field.units == 'degK':
-        print 'A temperature field in degK units! Changing units from K to C!...'
+        print('A temperature field in degK units! Changing units from K to '
+              'C!...')
         field_in = field_in - 273.15
         units = 'C'
 
     if field_name[0:3] == 'SST' and field.units == 'K':
-        print 'A temperature field in K units! Changing units from K to C!...'
+        print('A temperature field in K units! Changing units from K to C!...')
         field_in = field_in - 273.15
         units = 'C'
 
     if field_name[0:3] == 'TAU' and casename != 'ERS' and casename != 'COREv2_flux':
-        print 'Flipping sign of atm model wind stress values ...'
+        print('Flipping sign of atm model wind stress values ...')
         field_in = -field_in
 
     if field_name == 'LHFLX' and casename == 'COREv2_flux':
-        print 'Flipping sign of COREv2_flux LHFLX to define positive values for upward fluxes (ocean to atm) ...'
+        print('Flipping sign of COREv2_flux LHFLX to define positive values '
+              'for upward fluxes (ocean to atm) ...')
         field_in = -field_in
 
     if field_name == 'SHFLX' and casename == 'COREv2_flux':
-        print 'Flipping sign of COREv2_flux SHFLX to define positive values for upward fluxes (ocean to atm) ...'
+        print('Flipping sign of COREv2_flux SHFLX to define positive values '
+              'for upward fluxes (ocean to atm) ...')
         field_in = -field_in
 
-    if debug: print __name__, 'field_in[0,:,:]: ', field_in[0, :, :]
+    if debug:
+        print(__name__, 'field_in[0,:,:]: ', field_in[0, :, :])
 
     return (field_in, lat_reg, lon_reg, area_reg, units)

--- a/python/read_monthly_data_ts_field.py
+++ b/python/read_monthly_data_ts_field.py
@@ -63,7 +63,7 @@ def read_monthly_data_ts_field(indir,
     area = f.variables['area']
 
     nt = field.shape[0]
-    nyrs = nt/12
+    nyrs = nt // 12
 
 
     if end_month < begin_month:

--- a/python/read_monthly_data_ts_field.py
+++ b/python/read_monthly_data_ts_field.py
@@ -5,6 +5,9 @@
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import numpy
 from netCDF4 import Dataset
 from get_season_months_index import get_season_months_index

--- a/python/regress_index_field.py
+++ b/python/regress_index_field.py
@@ -1,10 +1,14 @@
 #
 # Copyright (c) 2017, UT-BATTELLE, LLC
 # All rights reserved.
-# 
+#
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
 from scipy import stats
 import numpy
 
@@ -13,12 +17,12 @@ def regress_index_field(index, field, lag = 0):
     nlat = field.shape[1]
     nt = field.shape[0]
 
-    regr_matrix   = numpy.ma.zeros((nlat, nlon)) 
-    const_matrix  = numpy.ma.zeros((nlat, nlon)) 
-    corr_matrix   = numpy.ma.zeros((nlat, nlon)) 
-    p_val_matrix  = numpy.ma.zeros((nlat, nlon)) 
-    t_test_matrix = numpy.ma.zeros((nlat, nlon)) 
-    stderr_matrix = numpy.ma.zeros((nlat, nlon)) 
+    regr_matrix   = numpy.ma.zeros((nlat, nlon))
+    const_matrix  = numpy.ma.zeros((nlat, nlon))
+    corr_matrix   = numpy.ma.zeros((nlat, nlon))
+    p_val_matrix  = numpy.ma.zeros((nlat, nlon))
+    t_test_matrix = numpy.ma.zeros((nlat, nlon))
+    stderr_matrix = numpy.ma.zeros((nlat, nlon))
 
     print __name__, 'type(field): ', type(field)
 
@@ -29,7 +33,7 @@ def regress_index_field(index, field, lag = 0):
         p_val_matrix.mask = field.mask[0, ::]
         t_test_matrix.mask = field.mask[0, ::]
         stderr_matrix.mask = field.mask[0, ::]
-        
+
         print __name__, 'field.mask: ', field.mask
         print __name__, 'field.mask.shape: ', field.mask.shape
         print __name__, 'regr_matrix.mask: ', regr_matrix.mask
@@ -43,12 +47,12 @@ def regress_index_field(index, field, lag = 0):
             else:
                 regr_matrix[j, i], const_matrix[j, i], corr_matrix[j, i], \
                 p_val_matrix[j, i], stderr_matrix[j, i] = stats.mstats.linregress(index[0:nt-lag], field[abs(lag):nt, j, i])
-                
-    
-        
-    t_test_matrix[numpy.where(p_val_matrix < 0.05)] = 1 
 
-    
+
+
+    t_test_matrix[numpy.where(p_val_matrix < 0.05)] = 1
+
+
     print __name__, 'type(regr_matrix): ', type(regr_matrix)
     print __name__, 'regr_matrix: ', regr_matrix
 

--- a/python/regress_index_field.py
+++ b/python/regress_index_field.py
@@ -24,7 +24,7 @@ def regress_index_field(index, field, lag = 0):
     t_test_matrix = numpy.ma.zeros((nlat, nlon))
     stderr_matrix = numpy.ma.zeros((nlat, nlon))
 
-    print __name__, 'type(field): ', type(field)
+    print(__name__, 'type(field): ', type(field))
 
     if numpy.ma.is_masked(field):
         regr_matrix.mask = field.mask[0, ::]
@@ -34,9 +34,9 @@ def regress_index_field(index, field, lag = 0):
         t_test_matrix.mask = field.mask[0, ::]
         stderr_matrix.mask = field.mask[0, ::]
 
-        print __name__, 'field.mask: ', field.mask
-        print __name__, 'field.mask.shape: ', field.mask.shape
-        print __name__, 'regr_matrix.mask: ', regr_matrix.mask
+        print(__name__, 'field.mask: ', field.mask)
+        print(__name__, 'field.mask.shape: ', field.mask.shape)
+        print(__name__, 'regr_matrix.mask: ', regr_matrix.mask)
 
 
     for i in range(0, nlon):
@@ -53,8 +53,8 @@ def regress_index_field(index, field, lag = 0):
     t_test_matrix[numpy.where(p_val_matrix < 0.05)] = 1
 
 
-    print __name__, 'type(regr_matrix): ', type(regr_matrix)
-    print __name__, 'regr_matrix: ', regr_matrix
+    print(__name__, 'type(regr_matrix): ', type(regr_matrix))
+    print(__name__, 'regr_matrix: ', regr_matrix)
 
     return regr_matrix, const_matrix, corr_matrix, t_test_matrix, stderr_matrix
 

--- a/python/remove_seasonal_cycle_monthly_data.py
+++ b/python/remove_seasonal_cycle_monthly_data.py
@@ -15,7 +15,7 @@ def remove_seasonal_cycle_monthly_data(field, n_months_season = 12, debug = Fals
     ntime = field.shape[0]
     field_noann = field + numpy.nan
 
-    nyrs = ntime/n_months_season
+    nyrs = ntime // n_months_season
     yrs = numpy.arange(0, nyrs)
 
     if debug: print(__name__, 'ntime, nyrs, yrs, field.ndim: ', ntime, nyrs,

--- a/python/remove_seasonal_cycle_monthly_data.py
+++ b/python/remove_seasonal_cycle_monthly_data.py
@@ -5,6 +5,9 @@
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import numpy
 
 def remove_seasonal_cycle_monthly_data(field, n_months_season = 12, debug = False):

--- a/python/remove_seasonal_cycle_monthly_data.py
+++ b/python/remove_seasonal_cycle_monthly_data.py
@@ -18,7 +18,8 @@ def remove_seasonal_cycle_monthly_data(field, n_months_season = 12, debug = Fals
     nyrs = ntime/n_months_season
     yrs = numpy.arange(0, nyrs)
 
-    if debug: print __name__, 'ntime, nyrs, yrs, field.ndim: ', ntime, nyrs, yrs, field.ndim
+    if debug: print(__name__, 'ntime, nyrs, yrs, field.ndim: ', ntime, nyrs,
+                    yrs, field.ndim)
 
     if field.ndim == 1:
         for i in range(0, n_months_season):
@@ -29,7 +30,7 @@ def remove_seasonal_cycle_monthly_data(field, n_months_season = 12, debug = Fals
             field_mean_temp = numpy.ma.mean(field[n_months_season*yrs + i, ::], axis = 0)
             field_noann[n_months_season*yrs + i, ::] = field[n_months_season*yrs + i, ::] - field_mean_temp
 
-    if debug: print __name__, 'field_noann: ', field_noann
+    if debug: print(__name__, 'field_noann: ', field_noann)
 
     return field_noann
 

--- a/python/round_to_first.py
+++ b/python/round_to_first.py
@@ -1,10 +1,14 @@
 #
 # Copyright (c) 2017, UT-BATTELLE, LLC
 # All rights reserved.
-# 
+#
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
 import math
 
 def round_to_first(x):

--- a/python/round_to_first_given_range.py
+++ b/python/round_to_first_given_range.py
@@ -1,10 +1,14 @@
 #
 # Copyright (c) 2017, UT-BATTELLE, LLC
 # All rights reserved.
-# 
+#
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
 import math
 
 def round_to_first_given_range(x, range_x):

--- a/python/setup_ocnice_config.py
+++ b/python/setup_ocnice_config.py
@@ -23,7 +23,8 @@ from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 import os
-import ConfigParser
+import six
+from six.moves.configparser import RawConfigParser
 
 
 def add_config_option(config, section, option, value):
@@ -39,7 +40,7 @@ def check_env(envVarName):
 inFileName = 'python/MPAS-Analysis/mpas_analysis/config.default'
 outFileName = os.environ['config_file']
 
-config = ConfigParser.RawConfigParser()
+config = RawConfigParser()
 config.read(inFileName)
 
 # Turn off generation of MPAS-Analysis html page by default

--- a/python/setup_ocnice_config.py
+++ b/python/setup_ocnice_config.py
@@ -16,8 +16,11 @@ Xylar Asay-Davis
 
 Modified
 --------
-2017/03/31
+2017/12/03
 '''
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import os
 import ConfigParser

--- a/python/standardize_time_series.py
+++ b/python/standardize_time_series.py
@@ -5,6 +5,10 @@
 # This software is released under the BSD license detailed
 # in the LICENSE file in the top level a-prime directory
 #
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
 import numpy
 
 def standardize_time_series(field):


### PR DESCRIPTION
Makes several different changes to make sure we can support python 3
* adds a futures statement to each python file so print is a function, division is float, etc. by default
* change print statements to be functions
* import `ConfigParser` from the `six` package for backward compatibility in python 3
* cast iterators to lists (e.g. `range()` when it's assigned to a variable rather than used in a `for` statement)
* integer division is performed with `//` rather than `/` (which performs float division even if the denominator is an integer)
* since explicit string expressions (between quotes) are now `unicode` objects in python 2, they occasionally need to be cast back to `str` before being past to code that does not expect `unicode` objects.